### PR TITLE
fix: Enable skipped GitHubSync initialization test

### DIFF
--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -12,11 +12,6 @@ from cli.integrations.github_sync import GitHubSync
 from cli.utils.config import Config
 
 
-@pytest.mark.skip(reason="Mock patching scope issues - needs refactoring")
-class TestGitHubSyncInitialization:
-    """Test GitHubSync initialization."""
-
-
 class TestGitHubSyncInitialization:
     """Test GitHubSync initialization."""
 


### PR DESCRIPTION
The TestGitHubSyncInitialization test class was incorrectly marked as skipped due to concerns about mock patching scope issues. However, all tests pass without any mock patching because they directly instantiate GitHubSync with a mock_config fixture.

This removes the @pytest.mark.skip decorator to enable the test.

Fixes #40