### PR TITLE
Fix failing CLI integration tests (Issue #60)

### DIFF
--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -288,7 +288,8 @@ Requirements:
             cwd=Path(__file__).parent.parent,
         )
 
-        assert result.returncode == 1
+        # Click exits with 2 for missing required options
+        assert result.returncode == 2
 
 
 class TestCLIKeywordAnalysis:
@@ -351,7 +352,8 @@ Requirements:
             cwd=Path(__file__).parent.parent,
         )
 
-        assert result.returncode == 1
+        # Click exits with 2 for missing required options
+        assert result.returncode == 2
 
 
 class TestCLIHelp:
@@ -373,8 +375,21 @@ class TestCLIHelp:
 
     def test_command_help(self):
         """Test individual command help displays."""
+        # Test main help shows commands
         result = subprocess.run(
             [sys.executable, "-m", "cli.main", "--help"],
+            capture_output=True,
+            text=True,
+            cwd=Path(__file__).parent.parent,
+        )
+
+        assert result.returncode == 0
+        assert "generate" in result.stdout
+        assert "validate" in result.stdout
+
+        # Test subcommand help shows options
+        result = subprocess.run(
+            [sys.executable, "-m", "cli.main", "generate", "--help"],
             capture_output=True,
             text=True,
             cwd=Path(__file__).parent.parent,
@@ -420,5 +435,7 @@ class TestCLIErrorHandling:
             cwd=Path(__file__).parent.parent,
         )
 
-        # Should either error or gracefully handle
-        assert "Error" in result.stdout or result.returncode != 0
+        # CLI gracefully falls back to base template when variant doesn't exist
+        # It should not crash and should produce output
+        assert result.returncode == 0
+        assert "Generated" in result.stdout or "resume" in result.stdout.lower()


### PR DESCRIPTION
Fixes 4 failing tests in tests/test_cli_commands.py:

1. **test_ats_check_missing_job_desc**: Changed expected return code from 1 to 2 (Click exits with 2 for missing required options)
2. **test_keyword_analysis_missing_job_desc**: Same fix as above
3. **test_command_help**: Changed to test subcommand help separately using 'generate --help' instead of main help
4. **test_invalid_variant**: Updated assertion to match current CLI behavior (gracefully falls back to base variant instead of erroring)