### PR TITLE
fix(issue-60): Fix failing CLI integration tests

### DIFF
--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -288,7 +288,9 @@ Requirements:
             cwd=Path(__file__).parent.parent,
         )
 
-        assert result.returncode == 1
+        # Click exits with 2 for missing required options
+        assert result.returncode == 2
+        assert "Missing option" in result.stderr or "Missing option" in result.stdout
 
 
 class TestCLIKeywordAnalysis:
@@ -351,7 +353,9 @@ Requirements:
             cwd=Path(__file__).parent.parent,
         )
 
-        assert result.returncode == 1
+        # Click exits with 2 for missing required options
+        assert result.returncode == 2
+        assert "Missing option" in result.stderr or "Missing option" in result.stdout
 
 
 class TestCLIHelp:
@@ -374,7 +378,7 @@ class TestCLIHelp:
     def test_command_help(self):
         """Test individual command help displays."""
         result = subprocess.run(
-            [sys.executable, "-m", "cli.main", "--help"],
+            [sys.executable, "-m", "cli.main", "generate", "--help"],
             capture_output=True,
             text=True,
             cwd=Path(__file__).parent.parent,
@@ -401,7 +405,7 @@ class TestCLIErrorHandling:
         assert "Error" in result.stdout or "not found" in result.stdout.lower()
 
     def test_invalid_variant(self, sample_yaml_file: Path):
-        """Test CLI handles invalid variant gracefully."""
+        """Test CLI handles invalid variant gracefully by falling back to base template."""
         result = subprocess.run(
             [
                 sys.executable,
@@ -420,5 +424,6 @@ class TestCLIErrorHandling:
             cwd=Path(__file__).parent.parent,
         )
 
-        # Should either error or gracefully handle
-        assert "Error" in result.stdout or result.returncode != 0
+        # CLI gracefully falls back to base template and succeeds
+        assert result.returncode == 0
+        assert "Generated:" in result.stdout


### PR DESCRIPTION
## Summary

Fixes 4 failing integration tests in `tests/test_cli_commands.py`:

1. **`test_ats_check_missing_job_desc`** - Updated assertion from return code 1 to 2 (Click exits with 2 for missing required options)

2. **`test_keyword_analysis_missing_job_desc`** - Same fix as above

3. **`test_command_help`** - Fixed to use `generate --help` instead of main `--help` to get subcommand help

4. **`test_invalid_variant`** - Updated to expect graceful fallback behavior (CLI creates variant using base template)

## Changes

- Updated test assertions to match current CLI behavior
- All 16 tests now pass

Closes #60
