### PR TITLE
fix(docker): Fix Docker build - api/requirements.txt not found (#96)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -52,6 +52,11 @@ tracking/SCHEMA.md
 *.yml
 !.env.template
 
+# Allow api directory (but exclude pycache)
+api/
+!api/
+!api/requirements.txt
+
 # Resume data
 resume.yaml
 resumes/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,11 @@ RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Install Python dependencies
-COPY requirements.txt api/requirements.txt ./
+COPY requirements.txt ./
+COPY api/requirements.txt ./api/
 RUN pip install --no-cache-dir --upgrade pip wheel && \
     pip install --no-cache-dir -r requirements.txt && \
-    pip install --no-cache-dir -r api/requirements.txt
+    pip install --no-cache-dir -r ./api/requirements.txt
 
 # =============================================================================
 # Stage 2: Runtime
@@ -48,7 +49,8 @@ COPY --from=builder /usr/local/bin/pip /usr/local/bin/pip
 # Set working directory
 WORKDIR /app
 
-# Copy application code
+# Copy application code and installation files
+COPY --chown=appuser:appgroup pyproject.toml setup.py ./
 COPY --chown=appuser:appgroup api/ api/
 COPY --chown=appuser:appgroup cli/ cli/
 COPY --chown=appuser:appgroup templates/ templates/


### PR DESCRIPTION
## Summary

Fixes the Docker build failure where `api/requirements.txt` could not be found during the build process.

## Problem

Docker builds were failing with:
```
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'api/requirements.txt'
```

## Root Cause

1. The `.dockerignore` file was excluding the `api/` directory
2. The Dockerfile COPY command was incorrectly specifying the source path for `api/requirements.txt`
3. The runtime stage was missing `pyproject.toml` and `setup.py` needed for editable install

## Changes

1. **`.dockerignore`**: Added rules to include `api/` directory and `api/requirements.txt`:
   ```dockerfile
   api/
   !api/
   !api/requirements.txt
   ```

2. **Dockerfile**: Fixed the COPY commands:
   - Builder stage: Copy `api/requirements.txt` to `./api/` instead of root
   - Runtime stage: Added `pyproject.toml` and `setup.py` to COPY commands

## Testing

- Docker build completes successfully
- CLI version command works: `docker run --rm test-build python -m cli.main --version`

## Related Issues

- Fixes #96