### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in PDF generation

### DIFF
--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -771,7 +771,7 @@ Return ONLY valid JSON, nothing else."""
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
@@ -787,7 +787,14 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        [
+                            "pandoc",
+                            str(tex_path),
+                            "-o",
+                            str(output_path),
+                            "--pdf-engine=xelatex",
+                            "--pdf-engine-opt=-no-shell-escape",
+                        ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -86,7 +86,7 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
@@ -121,7 +121,14 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                [
+                    "pandoc",
+                    str(tex_path),
+                    "-o",
+                    str(output_path),
+                    "--pdf-engine=xelatex",
+                    "--pdf-engine-opt=-no-shell-escape",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Command injection vulnerability identified in `cli/pdf/converter.py` and `cli/generators/cover_letter_generator.py`. `pdflatex` and `pandoc` system commands were executed using untrusted inputs via `subprocess.Popen` without the proper shell escape flags.
🎯 **Impact:** Allowed Remote Code Execution (RCE) via malicious LaTeX templates or manipulated user variables, breaking server security boundaries.
🔧 **Fix:** Replaced vulnerable instances of `subprocess.Popen` with safe executions by adding the `-no-shell-escape` flag to both `pdflatex` and `pandoc` (`--pdf-engine-opt=-no-shell-escape`) to disable \write18 executing arbitrary commands.
✅ **Verification:** Ran automated unit and integration tests successfully (`pytest`). No regressions observed.

---
*PR created automatically by Jules for task [15950278978229735209](https://jules.google.com/task/15950278978229735209) started by @anchapin*