### PR TITLE
⚡ Bolt: Pre-compile regex constants in JobParser

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-02-18 - Regex Pre-compilation in Hot Paths
 **Learning:** Re-compiling regexes inside a frequently called function (like `latex_escape` which runs for every string) creates significant overhead. Pre-compiling them at module level yielded a ~3.2x speedup.
 **Action:** Always look for regex compilations inside loops or frequently called functions and move them to module level constants.
+
+## 2025-02-18 - Avoid Over-precompilation
+**Learning:** Pre-compiling unused regex constants (like `EXPERIENCE_LEVEL_PATTERNS` and `BULLET_PATTERNS` when they aren't fully utilized in optimized methods) leaves unused dead code in the file, which reduces readability.
+**Action:** Only pre-compile regexes that are directly optimized in hot path methods, and ensure unused ones are safely removed to keep the code clean.

--- a/cli/integrations/job_parser.py
+++ b/cli/integrations/job_parser.py
@@ -19,7 +19,7 @@ import json
 import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from bs4 import BeautifulSoup, Tag
 
@@ -28,6 +28,23 @@ try:
     import requests
 except ImportError:
     requests = None
+
+
+# Pre-compiled regex patterns for performance
+SALARY_PATTERNS = [
+    re.compile(r"\$[\d,]+(?:\s*[-–to]+\s*\$[\d,]+)?", re.IGNORECASE),  # $100k - $150k
+    re.compile(r"\$[\d,]+k(?:\s*[-–to]+\s*\$[\d,]+k)?", re.IGNORECASE),  # $100k - $150k
+    re.compile(r"[\d,]+k(?:\s*[-–to]+\s*[\d,]+k)", re.IGNORECASE),  # 100k - 150k
+    re.compile(r"(?:salary|pay|compensation)[:\s]*(\$[^<>\n]+)", re.IGNORECASE),  # Salary: $X
+    re.compile(r"(?:per|/)\s*(?:year|annum)[:\s]*(\$[^<>\n]+)", re.IGNORECASE),  # per year: $X
+]
+
+JOB_TYPE_PATTERNS = [
+    re.compile(
+        r"\b(full[- ]?time|part[- ]?time|contract|freelance|intern|temporary)\b", re.IGNORECASE
+    ),
+    re.compile(r"\b(permanent|fixed[- ]?term)\b", re.IGNORECASE),
+]
 
 
 @dataclass
@@ -529,18 +546,22 @@ class JobParser:
                 return elem
         return None
 
-    def _extract_text_by_pattern(self, text: str, pattern: str) -> Optional[str]:
+    def _extract_text_by_pattern(self, text: str, pattern: Union[str, re.Pattern]) -> Optional[str]:
         """
         Extract text using regex pattern.
 
         Args:
             text: Text to search
-            pattern: Regex pattern
+            pattern: Regex pattern (string or pre-compiled)
 
         Returns:
             Extracted text or None
         """
-        match = re.search(pattern, text, re.IGNORECASE)
+        if isinstance(pattern, str):
+            match = re.search(pattern, text, re.IGNORECASE)
+        else:
+            match = pattern.search(text)
+
         if match:
             return match.group(1).strip()
         return None
@@ -555,17 +576,8 @@ class JobParser:
         Returns:
             Salary string or None
         """
-        # Common salary patterns
-        patterns = [
-            r"\$[\d,]+(?:\s*[-–to]+\s*\$[\d,]+)?",  # $100k - $150k
-            r"\$[\d,]+k(?:\s*[-–to]+\s*\$[\d,]+k)?",  # $100k - $150k
-            r"[\d,]+k(?:\s*[-–to]+\s*[\d,]+k)",  # 100k - 150k
-            r"(?:salary|pay|compensation)[:\s]*(\$[^<>\n]+)",  # Salary: $X
-            r"(?:per|/)\s*(?:year|annum)[:\s]*(\$[^<>\n]+)",  # per year: $X
-        ]
-
-        for pattern in patterns:
-            match = re.search(pattern, text, re.IGNORECASE)
+        for pattern in SALARY_PATTERNS:
+            match = pattern.search(text)
             if match:
                 salary = match.group(0) if match.lastindex is None else match.group(1)
                 # Clean up the salary string
@@ -805,13 +817,8 @@ class JobParser:
         Returns:
             Job type string or None
         """
-        patterns = [
-            r"\b(full[- ]?time|part[- ]?time|contract|freelance|intern|temporary)\b",
-            r"\b(permanent|fixed[- ]?term)\b",
-        ]
-
-        for pattern in patterns:
-            match = re.search(pattern, html, re.IGNORECASE)
+        for pattern in JOB_TYPE_PATTERNS:
+            match = pattern.search(html)
             if match:
                 return match.group(1).lower().replace("-", "-")
 


### PR DESCRIPTION
💡 **What:** 
Pre-compiled `SALARY_PATTERNS` and `JOB_TYPE_PATTERNS` in `cli/integrations/job_parser.py` into module-level variables. The `_extract_salary_from_text` and `_extract_job_type` functions were refactored to iterate over these pre-compiled lists. Type hints in `_extract_text_by_pattern` were updated to accept `Union[str, re.Pattern]` for future flexibility.

🎯 **Why:** 
The job parser processes entire raw HTML strings using lists of regular expressions. Re-evaluating lists of raw regex strings on every parse causes unnecessary overhead, as the strings must be parsed and cached internally by the `re` module. Extracting them to module-level constants skips this step entirely.

📊 **Impact:** 
Provides a minor but steady performance improvement (fewer compute cycles wasted on `re` internals), especially when repeatedly parsing large job description payloads in batch workflows or local caches.

🔬 **Measurement:** 
Run `pytest tests/test_job_parser_integration.py` to ensure salary and job type parsing behaves identically to the string-based version.

---
*PR created automatically by Jules for task [16092931447667214177](https://jules.google.com/task/16092931447667214177) started by @anchapin*