### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing -no-shell-escape in PDF compilation

### DIFF
--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -771,7 +771,7 @@ Return ONLY valid JSON, nothing else."""
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
@@ -787,7 +787,14 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        [
+                            "pandoc",
+                            str(tex_path),
+                            "-o",
+                            str(output_path),
+                            "--pdf-engine=xelatex",
+                            "--pdf-engine-opt=-no-shell-escape",
+                        ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -86,7 +86,7 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
@@ -121,7 +121,14 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                [
+                    "pandoc",
+                    str(tex_path),
+                    "-o",
+                    str(output_path),
+                    "--pdf-engine=xelatex",
+                    "--pdf-engine-opt=-no-shell-escape",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,

--- a/tests/test_pdf_security.py
+++ b/tests/test_pdf_security.py
@@ -7,6 +7,7 @@ from cli.generators.template import TemplateGenerator
 from cli.generators.cover_letter_generator import CoverLetterGenerator
 from cli.pdf.converter import PDFConverter
 
+
 class TestPDFSecurity(unittest.TestCase):
     @patch("cli.generators.template.subprocess.Popen")
     def test_pdflatex_timeout(self, mock_popen):
@@ -84,6 +85,7 @@ class TestPDFSecurity(unittest.TestCase):
 
         def popen_side_effect(*args, **kwargs):
             import subprocess
+
             if "pdflatex" in args[0]:
                 raise subprocess.CalledProcessError(1, "pdflatex")
             return process_mock

--- a/tests/test_pdf_security.py
+++ b/tests/test_pdf_security.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from cli.generators.template import TemplateGenerator
-
+from cli.generators.cover_letter_generator import CoverLetterGenerator
+from cli.pdf.converter import PDFConverter
 
 class TestPDFSecurity(unittest.TestCase):
     @patch("cli.generators.template.subprocess.Popen")
@@ -54,6 +55,90 @@ class TestPDFSecurity(unittest.TestCase):
         self.assertIn("-no-shell-escape", command)
         self.assertIn("-interaction=nonstopmode", command)
         self.assertIn("pdflatex", command)
+
+    @patch("subprocess.Popen")
+    def test_cover_letter_pdflatex_arguments(self, mock_popen):
+        # Setup mock
+        process_mock = MagicMock()
+        process_mock.communicate.return_value = (b"", b"")
+        process_mock.returncode = 0
+        mock_popen.return_value = process_mock
+
+        generator = CoverLetterGenerator()
+
+        with patch.object(Path, "exists", return_value=True):
+            generator._compile_pdf(Path("output.pdf"), "content")
+
+        args, _ = mock_popen.call_args
+        command = args[0]
+
+        self.assertIn("-no-shell-escape", command)
+        self.assertIn("pdflatex", command)
+
+    @patch("subprocess.Popen")
+    def test_cover_letter_pandoc_arguments(self, mock_popen):
+        # Setup mock to fail pdflatex and try pandoc
+        process_mock = MagicMock()
+        process_mock.communicate.return_value = (b"", b"")
+        process_mock.returncode = 0
+
+        def popen_side_effect(*args, **kwargs):
+            import subprocess
+            if "pdflatex" in args[0]:
+                raise subprocess.CalledProcessError(1, "pdflatex")
+            return process_mock
+
+        mock_popen.side_effect = popen_side_effect
+
+        generator = CoverLetterGenerator()
+
+        # Test pandoc arguments
+        with patch.object(Path, "exists", return_value=False):
+            generator._compile_pdf(Path("output.pdf"), "content")
+
+        args, _ = mock_popen.call_args_list[-1]
+        command = args[0]
+
+        self.assertIn("--pdf-engine-opt=-no-shell-escape", command)
+        self.assertIn("pandoc", command)
+
+    @patch("cli.pdf.converter.subprocess.Popen")
+    def test_pdf_converter_pdflatex_arguments(self, mock_popen):
+        # Setup mock
+        process_mock = MagicMock()
+        process_mock.communicate.return_value = (b"", b"")
+        process_mock.returncode = 0
+        mock_popen.return_value = process_mock
+
+        converter = PDFConverter()
+
+        with patch.object(Path, "exists", return_value=True):
+            converter._compile_pdflatex(Path("output.tex"), Path("output.pdf"), Path("."))
+
+        args, _ = mock_popen.call_args
+        command = args[0]
+
+        self.assertIn("-no-shell-escape", command)
+        self.assertIn("pdflatex", command)
+
+    @patch("subprocess.Popen")
+    def test_pdf_converter_pandoc_arguments(self, mock_popen):
+        # Setup mock
+        process_mock = MagicMock()
+        process_mock.communicate.return_value = (b"", b"")
+        process_mock.returncode = 0
+        mock_popen.return_value = process_mock
+
+        converter = PDFConverter()
+
+        with patch.object(Path, "exists", return_value=True):
+            converter._compile_pandoc(Path("output.tex"), Path("output.pdf"), Path("."))
+
+        args, _ = mock_popen.call_args
+        command = args[0]
+
+        self.assertIn("--pdf-engine-opt=-no-shell-escape", command)
+        self.assertIn("pandoc", command)
 
 
 if __name__ == "__main__":

--- a/tests/test_pdf_security.py
+++ b/tests/test_pdf_security.py
@@ -3,8 +3,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from cli.generators.template import TemplateGenerator
 from cli.generators.cover_letter_generator import CoverLetterGenerator
+from cli.generators.template import TemplateGenerator
 from cli.pdf.converter import PDFConverter
 
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `CoverLetterGenerator` and `PDFConverter` execute `pdflatex` and `pandoc` commands without explicitly disabling shell execution via the `-no-shell-escape` flag. LaTeX files with `\write18` could theoretically execute arbitrary system commands if user input reaches them.
🎯 Impact: This could result in a Remote Code Execution (RCE) vulnerability if an attacker manages to inject malicious LaTeX into a template via user data, allowing them to run shell commands on the server during PDF compilation.
🔧 Fix: Appended `-no-shell-escape` to all `pdflatex` calls and `--pdf-engine-opt=-no-shell-escape` to all `pandoc` fallback calls in `cli/generators/cover_letter_generator.py` and `cli/pdf/converter.py`. Expanded the test suite `tests/test_pdf_security.py` to enforce these arguments.
✅ Verification: Ran `pytest tests/test_pdf_security.py` and verified the new mock tests pass, asserting that the compilation functions generate commands with the exact security flags.

---
*PR created automatically by Jules for task [2524773504874773230](https://jules.google.com/task/2524773504874773230) started by @anchapin*