### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection and DoS in PDF compilation

### DIFF
--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -771,15 +771,21 @@ Return ONLY valid JSON, nothing else."""
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
+
             if process.returncode == 0 or output_path.exists():
                 pdf_created = True
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (subprocess.CalledProcessError, FileNotFoundError, RuntimeError):
             # Check if PDF was created anyway
             if output_path.exists():
                 pdf_created = True
@@ -787,14 +793,27 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        [
+                            "pandoc",
+                            str(tex_path),
+                            "-o",
+                            str(output_path),
+                            "--pdf-engine=xelatex",
+                            "--pdf-engine-opt=-no-shell-escape",
+                        ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )
-                    stdout, stderr = process.communicate()
+                    try:
+                        stdout, stderr = process.communicate(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        stdout, stderr = process.communicate()
+                        raise RuntimeError("PDF compilation timed out")
+
                     if process.returncode == 0 or output_path.exists():
                         pdf_created = True
-                except (subprocess.CalledProcessError, FileNotFoundError):
+                except (subprocess.CalledProcessError, FileNotFoundError, RuntimeError):
                     pass
 
         if not pdf_created or not output_path.exists():

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -86,16 +86,21 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
 
             if process.returncode == 0 or output_path.exists():
                 return True
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (subprocess.CalledProcessError, FileNotFoundError, RuntimeError):
             # Check if PDF was created anyway (pdflatex returns non-zero for warnings)
             if output_path.exists():
                 return True
@@ -121,16 +126,28 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                [
+                    "pandoc",
+                    str(tex_path),
+                    "-o",
+                    str(output_path),
+                    "--pdf-engine=xelatex",
+                    "--pdf-engine-opt=-no-shell-escape",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
 
             if process.returncode == 0 or output_path.exists():
                 return True
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (subprocess.CalledProcessError, FileNotFoundError, RuntimeError):
             pass
 
         return False


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unrestricted shell execution (`\write18`) via LaTeX compilation and missing subprocess timeouts.
🎯 **Impact:** Remote Code Execution (RCE) via malicious LaTeX templates or AI-generated content containing `\write18` or `\input` commands. Denial of Service (DoS) if compilation enters an infinite loop.
🔧 **Fix:** 
- Enforced `-no-shell-escape` flag on both `pdflatex` and `pandoc` compilation commands in `cli/pdf/converter.py` and `cli/generators/cover_letter_generator.py`.
- Added a 30-second `timeout` to all `process.communicate()` calls and proper process killing when `TimeoutExpired` is caught.
✅ **Verification:** Verified by running the existing `make test` test suite and confirming no regressions were introduced. Tests checking PDF compilation were successfully adapted (or naturally passed) with the new secure arguments.

---
*PR created automatically by Jules for task [10610597043180277026](https://jules.google.com/task/10610597043180277026) started by @anchapin*