### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix RCE vulnerability in PDF compilation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `CoverLetterGenerator` used a standard Jinja2 environment (intended for HTML/XML or plain text) to render LaTeX templates. This allowed malicious user input (or AI hallucinations) containing LaTeX control characters (e.g., `\input{...}`) to be injected directly into the LaTeX source, leading to potential Local File Inclusion (LFI) or other exploits.
 **Learning:** Jinja2's default `autoescape` is context-aware based on file extensions, but usually only for HTML/XML. It does NOT automatically escape LaTeX special characters. Relying on manual filters (like `| latex_escape`) in templates is error-prone and brittle, as developers might forget to apply them to every variable.
 **Prevention:** Always use a dedicated Jinja2 environment for LaTeX generation that enforces auto-escaping via a `finalize` hook (e.g., `tex_env.finalize = latex_escape`). This ensures *all* variable output is sanitized by default, providing defense-in-depth even if the template author forgets explicit filters.
+
+## 2026-03-13 - [Critical] PDF Compilation RCE Risk
+**Vulnerability:** The `CoverLetterGenerator` and `PDFConverter` did not pass the `-no-shell-escape` flag to `pdflatex` or `pandoc` and lacked a timeout for the subprocess.
+**Learning:** LaTeX allows executing arbitrary shell commands via `\write18` if shell escape is not explicitly disabled, which can lead to Remote Code Execution (RCE). Without timeouts, malicious input can also cause Denial of Service (DoS) by creating infinite compilation loops.
+**Prevention:** Ensure all invocations of `pdflatex` include `-no-shell-escape` and `pandoc` include `--pdf-engine-opt=-no-shell-escape`. Always use `subprocess.communicate(timeout=30)` and handle `TimeoutExpired` to kill hanging processes.

--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import re
 import sys
+import subprocess
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -765,18 +766,22 @@ Return ONLY valid JSON, nothing else."""
             f.write(tex_content)
 
         # Try pdflatex first
-        import subprocess
-
         pdf_created = False
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
+
             if process.returncode == 0 or output_path.exists():
                 pdf_created = True
         except (subprocess.CalledProcessError, FileNotFoundError):
@@ -787,11 +792,24 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        [
+                            "pandoc",
+                            str(tex_path),
+                            "-o",
+                            str(output_path),
+                            "--pdf-engine=xelatex",
+                            "--pdf-engine-opt=-no-shell-escape",
+                        ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )
-                    stdout, stderr = process.communicate()
+                    try:
+                        stdout, stderr = process.communicate(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        stdout, stderr = process.communicate()
+                        raise RuntimeError("PDF compilation timed out")
+
                     if process.returncode == 0 or output_path.exists():
                         pdf_created = True
                 except (subprocess.CalledProcessError, FileNotFoundError):

--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -5,8 +5,8 @@
 import hashlib
 import os
 import re
-import sys
 import subprocess
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -86,12 +86,17 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
 
             if process.returncode == 0 or output_path.exists():
                 return True
@@ -121,12 +126,24 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                [
+                    "pandoc",
+                    str(tex_path),
+                    "-o",
+                    str(output_path),
+                    "--pdf-engine=xelatex",
+                    "--pdf-engine-opt=-no-shell-escape",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
 
             if process.returncode == 0 or output_path.exists():
                 return True

--- a/tests/test_pdf_security.py
+++ b/tests/test_pdf_security.py
@@ -4,11 +4,13 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from cli.generators.template import TemplateGenerator
+from cli.generators.cover_letter_generator import CoverLetterGenerator
+from cli.pdf.converter import PDFConverter
 
 
 class TestPDFSecurity(unittest.TestCase):
     @patch("cli.generators.template.subprocess.Popen")
-    def test_pdflatex_timeout(self, mock_popen):
+    def test_template_generator_pdflatex_timeout(self, mock_popen):
         # Setup mock
         process_mock = MagicMock()
         # Raise TimeoutExpired on first call, return empty bytes on second call (cleanup)
@@ -33,7 +35,7 @@ class TestPDFSecurity(unittest.TestCase):
         process_mock.communicate.assert_any_call(timeout=30)
 
     @patch("cli.generators.template.subprocess.Popen")
-    def test_pdflatex_arguments(self, mock_popen):
+    def test_template_generator_pdflatex_arguments(self, mock_popen):
         # Setup mock
         process_mock = MagicMock()
         process_mock.communicate.return_value = (b"", b"")
@@ -54,6 +56,77 @@ class TestPDFSecurity(unittest.TestCase):
         self.assertIn("-no-shell-escape", command)
         self.assertIn("-interaction=nonstopmode", command)
         self.assertIn("pdflatex", command)
+
+    @patch("cli.pdf.converter.subprocess.Popen")
+    def test_pdfconverter_pdflatex_arguments(self, mock_popen):
+        # Setup mock
+        process_mock = MagicMock()
+        process_mock.communicate.return_value = (b"", b"")
+        process_mock.returncode = 0
+        mock_popen.return_value = process_mock
+
+        converter = PDFConverter()
+
+        with patch.object(Path, "exists", return_value=True):
+            converter._compile_pdflatex(Path("output.tex"), Path("output.pdf"), Path("."))
+
+        args, _ = mock_popen.call_args
+        command = args[0]
+
+        self.assertIn("-no-shell-escape", command)
+        self.assertIn("-interaction=nonstopmode", command)
+        self.assertIn("pdflatex", command)
+
+    @patch("cli.pdf.converter.subprocess.Popen")
+    def test_pdfconverter_pandoc_arguments(self, mock_popen):
+        # Setup mock
+        process_mock = MagicMock()
+        process_mock.communicate.return_value = (b"", b"")
+        process_mock.returncode = 0
+        mock_popen.return_value = process_mock
+
+        converter = PDFConverter()
+
+        with patch.object(Path, "exists", return_value=True):
+            converter._compile_pandoc(Path("output.tex"), Path("output.pdf"), Path("."))
+
+        args, _ = mock_popen.call_args
+        command = args[0]
+
+        self.assertIn("--pdf-engine-opt=-no-shell-escape", command)
+        self.assertIn("pandoc", command)
+
+    @patch("cli.generators.cover_letter_generator.subprocess.Popen")
+    def test_cover_letter_generator_pdflatex_arguments(self, mock_popen):
+        # Setup mock
+        process_mock = MagicMock()
+        process_mock.communicate.return_value = (b"", b"")
+        process_mock.returncode = 0
+        mock_popen.return_value = process_mock
+
+        # Setup mock for CoverLetterGenerator
+        with patch("cli.generators.cover_letter_generator.Config") as MockConfig:
+            mock_config = MagicMock()
+            mock_config.output_dir = "test_output"
+            mock_config.ai_provider = "anthropic"
+            mock_config.get.return_value = "anthropic"
+            MockConfig.return_value = mock_config
+            with patch("cli.generators.cover_letter_generator.anthropic") as mock_anthropic:
+                generator = CoverLetterGenerator(
+                    resume_data={"contact": {"name": "Test"}}, config=mock_config
+                )
+
+                # Run compilation
+                with patch.object(Path, "exists", return_value=True):
+                    generator._compile_pdf(Path("output.pdf"), "content")
+
+            # Verify arguments
+            args, _ = mock_popen.call_args
+            command = args[0]
+
+            self.assertIn("-no-shell-escape", command)
+            self.assertIn("-interaction=nonstopmode", command)
+            self.assertIn("pdflatex", command)
 
 
 if __name__ == "__main__":

--- a/tests/test_pdf_security.py
+++ b/tests/test_pdf_security.py
@@ -3,8 +3,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from cli.generators.template import TemplateGenerator
 from cli.generators.cover_letter_generator import CoverLetterGenerator
+from cli.generators.template import TemplateGenerator
 from cli.pdf.converter import PDFConverter
 
 
@@ -111,7 +111,7 @@ class TestPDFSecurity(unittest.TestCase):
             mock_config.ai_provider = "anthropic"
             mock_config.get.return_value = "anthropic"
             MockConfig.return_value = mock_config
-            with patch("cli.generators.cover_letter_generator.anthropic") as mock_anthropic:
+            with patch("cli.generators.cover_letter_generator.anthropic"):
                 generator = CoverLetterGenerator(
                     resume_data={"contact": {"name": "Test"}}, config=mock_config
                 )


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: PDF generation via pdflatex and pandoc allowed execution of arbitrary shell commands because the shell escape mechanism was not disabled (`-no-shell-escape`). It also lacked a timeout, making it vulnerable to Denial of Service via hanging compilations.
🎯 Impact: Remote Code Execution (RCE) on the host machine and Denial of Service (DoS).
🔧 Fix: Passed the `-no-shell-escape` flag to pdflatex and `--pdf-engine-opt=-no-shell-escape` to pandoc in `CoverLetterGenerator` and `PDFConverter`. Added `timeout=30` and proper process killing to `subprocess.communicate`.
✅ Verification: Tested via unit tests (`test_pdf_security.py`). Run `make test` to verify.

---
*PR created automatically by Jules for task [4964436685612997103](https://jules.google.com/task/4964436685612997103) started by @anchapin*