### PR TITLE
🛡️ Sentinel: [security improvement] Replace MD5 with SHA-256 for cache keys

### DIFF
--- a/cli/integrations/job_parser.py
+++ b/cli/integrations/job_parser.py
@@ -849,8 +849,7 @@ class JobParser:
         Returns:
             Hash string for caching
         """
-        # Note: MD5 is used for cache keys only, not for security purposes
-        return hashlib.md5(url.encode()).hexdigest()  # nosec
+        return hashlib.sha256(url.encode()).hexdigest()
 
     def _get_from_cache(self, cache_key: str) -> Optional[JobDetails]:
         """


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: `hashlib.md5` was used to generate cache keys in `cli/integrations/job_parser.py`. While the comment noted it wasn't used for security, MD5 is cryptographically weak and flags in static analysis tools (like Bandit).
🎯 Impact: Using MD5 triggers security scanners and establishes a poor hashing pattern in the codebase, even if technically non-exploitable in this context.
🔧 Fix: Replaced `hashlib.md5` with `hashlib.sha256` for cache key generation. Removed the `# nosec` suppression flag as it is no longer needed. Kept `usedforsecurity=False` off to maintain Python 3.8 compatibility.
✅ Verification: Ran `pytest` locally to ensure the caching tests continue to pass with the new SHA-256 keys.

---
*PR created automatically by Jules for task [1418828044505652609](https://jules.google.com/task/1418828044505652609) started by @anchapin*

## Summary by Sourcery

Enhancements:
- Update cache key hashing in the job parser from MD5 to SHA-256 to align with stronger cryptographic practices.