### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix RCE in PDF compilation

### DIFF
--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -792,7 +792,14 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex", "--pdf-engine-opt=-no-shell-escape"],
+                        [
+                            "pandoc",
+                            str(tex_path),
+                            "-o",
+                            str(output_path),
+                            "--pdf-engine=xelatex",
+                            "--pdf-engine-opt=-no-shell-escape",
+                        ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )

--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -771,12 +771,17 @@ Return ONLY valid JSON, nothing else."""
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                return False
             if process.returncode == 0 or output_path.exists():
                 pdf_created = True
         except (subprocess.CalledProcessError, FileNotFoundError):
@@ -787,11 +792,16 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex", "--pdf-engine-opt=-no-shell-escape"],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )
-                    stdout, stderr = process.communicate()
+                    try:
+                        stdout, stderr = process.communicate(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        stdout, stderr = process.communicate()
+                        return False
                     if process.returncode == 0 or output_path.exists():
                         pdf_created = True
                 except (subprocess.CalledProcessError, FileNotFoundError):

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -126,7 +126,14 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex", "--pdf-engine-opt=-no-shell-escape"],
+                [
+                    "pandoc",
+                    str(tex_path),
+                    "-o",
+                    str(output_path),
+                    "--pdf-engine=xelatex",
+                    "--pdf-engine-opt=-no-shell-escape",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -86,12 +86,17 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                return False
 
             if process.returncode == 0 or output_path.exists():
                 return True
@@ -121,12 +126,17 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex", "--pdf-engine-opt=-no-shell-escape"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                return False
 
             if process.returncode == 0 or output_path.exists():
                 return True


### PR DESCRIPTION
**🚨 Severity:** CRITICAL
**💡 Vulnerability:** The `CoverLetterGenerator` and `PDFConverter` classes were using `pdflatex` and `pandoc` to compile LaTeX source into PDFs. However, they lacked the `-no-shell-escape` flag and a subprocess timeout. This allows an attacker (or hallucinating AI) to inject LaTeX code capable of executing arbitrary shell commands via `\write18` or perform Local File Inclusion (LFI). Additionally, an untrusted compilation could cause infinite loops resulting in Denial of Service (DoS).
**🎯 Impact:** A user generating a cover letter from an AI output or converting a manipulated `.tex` file could experience a full Remote Code Execution (RCE) on their machine, or a complete process hang.
**🔧 Fix:** Added the `-no-shell-escape` flag to both `pdflatex` directly and `pandoc` (via `--pdf-engine-opt=-no-shell-escape`). Also added a 30-second timeout to `process.communicate(timeout=30)`, gracefully catching the exception to kill the process to prevent zombie processes.
**✅ Verification:** Ran `pytest tests/test_pdf_security.py` and `pytest tests/test_cover_letter_security.py` to ensure the vulnerability is mitigated. Also executed the full `pytest` suite ensuring 681 tests pass cleanly.

---
*PR created automatically by Jules for task [6615092504026383693](https://jules.google.com/task/6615092504026383693) started by @anchapin*

## Summary by Sourcery

Harden LaTeX-based PDF generation against remote code execution and hangs in both cover letter generation and generic PDF conversion flows.

Bug Fixes:
- Prevent LaTeX and pandoc PDF compilation from executing arbitrary shell commands by disabling shell escape in pdflatex and the pandoc PDF engine.
- Mitigate potential denial-of-service from untrusted LaTeX input by enforcing a timeout on external PDF compilation processes and aborting on long-running jobs.