### PR TITLE
⚡ Bolt: Offload blocking I/O to anyio in FastAPI routes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-02-18 - Regex Pre-compilation in Hot Paths
 **Learning:** Re-compiling regexes inside a frequently called function (like `latex_escape` which runs for every string) creates significant overhead. Pre-compiling them at module level yielded a ~3.2x speedup.
 **Action:** Always look for regex compilations inside loops or frequently called functions and move them to module level constants.
+
+## 2025-02-18 - anyio for Blocking I/O in FastAPI
+**Learning:** Blocking operations like PDF compilation and file I/O in FastAPI routes block the single-threaded event loop, leading to performance degradation under load.
+**Action:** Wrap blocking I/O bound tasks in FastAPI endpoints with `anyio.to_thread.run_sync` (and `functools.partial` when needed) to offload work to worker threads.

--- a/api/main.py
+++ b/api/main.py
@@ -1,8 +1,10 @@
+import functools
 import logging
 import os
 import tempfile
 from pathlib import Path
 
+import anyio
 import yaml
 from fastapi import FastAPI, HTTPException, Response, Security
 from fastapi.middleware.cors import CORSMiddleware
@@ -171,13 +173,20 @@ async def render_pdf(request: ResumeRequest):
             # We output to a temp file
             output_pdf = temp_path / "output.pdf"
 
-            generator.generate(variant=request.variant, output_format="pdf", output_path=output_pdf)
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    generator.generate,
+                    variant=request.variant,
+                    output_format="pdf",
+                    output_path=output_pdf,
+                )
+            )
 
-            if not output_pdf.exists():
+            if not await anyio.to_thread.run_sync(output_pdf.exists):
                 raise HTTPException(status_code=500, detail="PDF generation failed")
 
             # Read bytes
-            content = output_pdf.read_bytes()
+            content = await anyio.to_thread.run_sync(output_pdf.read_bytes)
 
             return Response(
                 content=content,
@@ -323,11 +332,15 @@ async def generate_cover_letter(request: CoverLetterRequest):
 
                 # Compile LaTeX to PDF
                 pdf_path = temp_path / "cover-letter.pdf"
-                if generator._compile_pdf(pdf_path, outputs["pdf"]):
+
+                compile_success = await anyio.to_thread.run_sync(
+                    functools.partial(generator._compile_pdf, pdf_path, outputs["pdf"])
+                )
+
+                if compile_success:
                     import base64
 
-                    with open(pdf_path, "rb") as f:
-                        pdf_bytes = f.read()
+                    pdf_bytes = await anyio.to_thread.run_sync(pdf_path.read_bytes)
                     return {
                         "content": base64.b64encode(pdf_bytes).decode("utf-8"),
                         "format": "pdf",
@@ -553,19 +566,28 @@ async def render_resume_pdf(resume_id: str, variant: str = "base"):
         converter = JSONResumeConverter()
         yaml_data = converter.json_resume_to_yaml(_resume_storage[resume_id]["json_resume"])
 
-        with open(resume_yaml_path, "w", encoding="utf-8") as f:
-            yaml.dump(yaml_data, f, default_flow_style=False)
+        yaml_str = yaml.dump(yaml_data, default_flow_style=False)
+        await anyio.to_thread.run_sync(
+            functools.partial(resume_yaml_path.write_text, yaml_str, encoding="utf-8")
+        )
 
         try:
             generator = TemplateGenerator(yaml_path=resume_yaml_path)
             output_pdf = temp_path / "output.pdf"
 
-            generator.generate(variant=variant, output_format="pdf", output_path=output_pdf)
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    generator.generate,
+                    variant=variant,
+                    output_format="pdf",
+                    output_path=output_pdf,
+                )
+            )
 
-            if not output_pdf.exists():
+            if not await anyio.to_thread.run_sync(output_pdf.exists):
                 raise HTTPException(status_code=500, detail="PDF generation failed")
 
-            content = output_pdf.read_bytes()
+            content = await anyio.to_thread.run_sync(output_pdf.read_bytes)
 
             return Response(
                 content=content,


### PR DESCRIPTION
💡 What: Wrapped blocking synchronous operations (`generator.generate`, `Path.read_bytes`, `Path.exists`, `generator._compile_pdf`, etc.) in the `api/main.py` FastAPI routes with `anyio.to_thread.run_sync` (and `functools.partial` when arguments were needed).
🎯 Why: FastAPI's `async def` routes run on the main event loop. Any blocking synchronous call in these routes (like running `pdflatex` or reading files) stalls the entire application, making it unable to process other incoming concurrent requests. This causes significant performance degradation under load.
📊 Impact: Considerably improves concurrent performance by offloading CPU-bound or blocking I/O tasks to worker threads, freeing up the FastAPI event loop to handle hundreds of concurrent requests simultaneously.
🔬 Measurement: Run load tests using `locust` or `wrk` against the `/v1/render/pdf` or `/v1/cover-letter` API endpoints to observe improved throughput and decreased P99 latencies under concurrent load.

---
*PR created automatically by Jules for task [15037805867948622709](https://jules.google.com/task/15037805867948622709) started by @anchapin*

## Summary by Sourcery

Offload blocking PDF generation and file I/O in FastAPI resume and cover-letter endpoints to background threads using anyio to prevent blocking the event loop and improve concurrency.

Enhancements:
- Wrap synchronous PDF generation, LaTeX compilation, and file read/write operations in FastAPI routes with anyio.to_thread.run_sync to avoid blocking the async event loop.
- Adjust resume YAML serialization to generate the YAML string in memory and write it via a non-blocking threaded file write.
- Document the performance lesson about using anyio for blocking I/O in FastAPI in .jules/bolt.md for future optimizations.