### PR TITLE
⚡ Bolt: Offload blocking I/O operations to worker threads in async FastAPI routes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-02-18 - Regex Pre-compilation in Hot Paths
 **Learning:** Re-compiling regexes inside a frequently called function (like `latex_escape` which runs for every string) creates significant overhead. Pre-compiling them at module level yielded a ~3.2x speedup.
 **Action:** Always look for regex compilations inside loops or frequently called functions and move them to module level constants.
+
+## 2025-02-18 - Offloading Blocking I/O in FastAPI
+**Learning:** Fastapi endpoints using `async def` run on the main event loop. Blocking operations like `generator.generate()` (which involves CPU-bound work and LaTeX compilation) and filesystem I/O (`Path.read_bytes()`, `Path.exists()`) block the event loop, severely degrading concurrent request handling performance.
+**Action:** Use `anyio.to_thread.run_sync()` to offload synchronous, blocking operations in `async` endpoints. For functions with keyword arguments, use `functools.partial` since `run_sync` only accepts positional arguments.

--- a/api/main.py
+++ b/api/main.py
@@ -1,8 +1,10 @@
 import logging
 import os
 import tempfile
+from functools import partial
 from pathlib import Path
 
+import anyio
 import yaml
 from fastapi import FastAPI, HTTPException, Response, Security
 from fastapi.middleware.cors import CORSMiddleware
@@ -171,13 +173,22 @@ async def render_pdf(request: ResumeRequest):
             # We output to a temp file
             output_pdf = temp_path / "output.pdf"
 
-            generator.generate(variant=request.variant, output_format="pdf", output_path=output_pdf)
+            # Offload blocking PDF generation to a worker thread
+            generate_func = partial(
+                generator.generate,
+                variant=request.variant,
+                output_format="pdf",
+                output_path=output_pdf,
+            )
+            await anyio.to_thread.run_sync(generate_func)
 
-            if not output_pdf.exists():
+            # Offload blocking filesystem checks and reads
+            exists = await anyio.to_thread.run_sync(output_pdf.exists)
+            if not exists:
                 raise HTTPException(status_code=500, detail="PDF generation failed")
 
             # Read bytes
-            content = output_pdf.read_bytes()
+            content = await anyio.to_thread.run_sync(output_pdf.read_bytes)
 
             return Response(
                 content=content,
@@ -560,12 +571,21 @@ async def render_resume_pdf(resume_id: str, variant: str = "base"):
             generator = TemplateGenerator(yaml_path=resume_yaml_path)
             output_pdf = temp_path / "output.pdf"
 
-            generator.generate(variant=variant, output_format="pdf", output_path=output_pdf)
+            # Offload blocking PDF generation
+            generate_func = partial(
+                generator.generate,
+                variant=variant,
+                output_format="pdf",
+                output_path=output_pdf,
+            )
+            await anyio.to_thread.run_sync(generate_func)
 
-            if not output_pdf.exists():
+            # Offload blocking I/O
+            exists = await anyio.to_thread.run_sync(output_pdf.exists)
+            if not exists:
                 raise HTTPException(status_code=500, detail="PDF generation failed")
 
-            content = output_pdf.read_bytes()
+            content = await anyio.to_thread.run_sync(output_pdf.read_bytes)
 
             return Response(
                 content=content,


### PR DESCRIPTION
💡 What: Offloaded blocking synchronous operations (`generator.generate`, `Path.exists`, `Path.read_bytes`) in FastAPI endpoints `render_pdf` and `render_resume_pdf` to worker threads using `anyio.to_thread.run_sync` and `functools.partial`.
🎯 Why: FastAPI endpoints defined with `async def` run directly on the main async event loop. Executing blocking, CPU-bound tasks (like LaTeX PDF compilation in `generator.generate`) and synchronous file I/O operations on the main thread blocked the event loop. This caused a major concurrency bottleneck, completely starving the server from handling other incoming requests while a PDF was being generated or read.
📊 Impact: Significantly improves the API's concurrent request handling capabilities. The event loop is no longer blocked during expensive PDF generations and file reads, avoiding total server freezes under load.
🔬 Measurement: Verify by running load tests against the `/v1/render/pdf` or `/v1/resumes/{id}/render/pdf` endpoints. You should observe much better concurrent processing times without the server pausing entirely during individual request execution. Run test suite via `python -m pytest` to confirm everything works as expected.

---
*PR created automatically by Jules for task [18003314079667917910](https://jules.google.com/task/18003314079667917910) started by @anchapin*

## Summary by Sourcery

Offload blocking PDF generation and file I/O in async FastAPI PDF rendering endpoints to worker threads to improve concurrency and responsiveness.

Enhancements:
- Run synchronous PDF generation and filesystem operations in `render_pdf` and `render_resume_pdf` via worker threads instead of the main event loop.

Documentation:
- Document the performance impact and best practices for offloading blocking I/O in FastAPI async endpoints in the Bolt engineering notes.