### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Remote Code Execution in PDF compilation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `CoverLetterGenerator` used a standard Jinja2 environment (intended for HTML/XML or plain text) to render LaTeX templates. This allowed malicious user input (or AI hallucinations) containing LaTeX control characters (e.g., `\input{...}`) to be injected directly into the LaTeX source, leading to potential Local File Inclusion (LFI) or other exploits.
 **Learning:** Jinja2's default `autoescape` is context-aware based on file extensions, but usually only for HTML/XML. It does NOT automatically escape LaTeX special characters. Relying on manual filters (like `| latex_escape`) in templates is error-prone and brittle, as developers might forget to apply them to every variable.
 **Prevention:** Always use a dedicated Jinja2 environment for LaTeX generation that enforces auto-escaping via a `finalize` hook (e.g., `tex_env.finalize = latex_escape`). This ensures *all* variable output is sanitized by default, providing defense-in-depth even if the template author forgets explicit filters.
+
+## 2024-05-18 - 🛡️ Sentinel: [CRITICAL/HIGH] Fix Remote Code Execution in PDF compilation
+**Vulnerability:** Subprocess `pdflatex` / `pandoc` executed without `-no-shell-escape` and missing timeout.
+**Learning:** Malicious inputs in Cover Letters or templates can execute arbitrary shell code via LaTeX `\write18` or `\immediate\write18` capabilities or cause Denial of Service by infinitely compiling.
+**Prevention:** All PDF compilation tools must invoke `-no-shell-escape` explicitly, and utilize process `timeout` via `process.communicate(timeout=X)` and catching `subprocess.TimeoutExpired`.

--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -771,12 +771,18 @@ Return ONLY valid JSON, nothing else."""
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                return False
+
             if process.returncode == 0 or output_path.exists():
                 pdf_created = True
         except (subprocess.CalledProcessError, FileNotFoundError):
@@ -787,11 +793,24 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        [
+                            "pandoc",
+                            str(tex_path),
+                            "-o",
+                            str(output_path),
+                            "--pdf-engine=xelatex",
+                            "--pdf-engine-opt=-no-shell-escape",
+                        ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )
-                    stdout, stderr = process.communicate()
+                    try:
+                        stdout, stderr = process.communicate(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        stdout, stderr = process.communicate()
+                        return False
+
                     if process.returncode == 0 or output_path.exists():
                         pdf_created = True
                 except (subprocess.CalledProcessError, FileNotFoundError):


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Subprocess `pdflatex` and `pandoc` executed without `-no-shell-escape` flag and missing timeout.
🎯 Impact: Malicious inputs in Cover Letters or templates could execute arbitrary shell code via LaTeX `\write18` capabilities or cause Denial of Service by infinitely compiling.
🔧 Fix: Add `-no-shell-escape` flag and process timeouts to PDF compilation logic in `CoverLetterGenerator._compile_pdf`.
✅ Verification: Ran test suite locally using `python -m pytest tests/test_cover_letter_generator.py` and validated passing tests. Included updated Sentinel Journal entry.

---
*PR created automatically by Jules for task [1606002574241256488](https://jules.google.com/task/1606002574241256488) started by @anchapin*

## Summary by Sourcery

Harden PDF compilation for cover letters against remote code execution and runaway LaTeX processes.

Bug Fixes:
- Prevent LaTeX-based remote code execution by disabling shell escape for pdflatex and pandoc-driven PDF generation.
- Mitigate denial-of-service risk from hung or infinitely compiling LaTeX processes by enforcing timeouts on PDF compilation subprocesses.

Documentation:
- Add a Sentinel security journal entry documenting the LaTeX PDF compilation RCE and DoS vulnerability and its mitigation.