### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in PDF generation

### DIFF
--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -771,12 +771,18 @@ Return ONLY valid JSON, nothing else."""
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                return False
+
             if process.returncode == 0 or output_path.exists():
                 pdf_created = True
         except (subprocess.CalledProcessError, FileNotFoundError):
@@ -787,11 +793,24 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        [
+                            "pandoc",
+                            str(tex_path),
+                            "-o",
+                            str(output_path),
+                            "--pdf-engine=xelatex",
+                            "--pdf-engine-opt=-no-shell-escape",
+                        ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )
-                    stdout, stderr = process.communicate()
+                    try:
+                        stdout, stderr = process.communicate(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        stdout, stderr = process.communicate()
+                        return False
+
                     if process.returncode == 0 or output_path.exists():
                         pdf_created = True
                 except (subprocess.CalledProcessError, FileNotFoundError):


### PR DESCRIPTION
**Severity:** CRITICAL
**Vulnerability:** The `_compile_pdf` method in `CoverLetterGenerator` executed `pdflatex` and `pandoc` without the `-no-shell-escape` flag. LaTeX's shell escape feature could be abused to execute arbitrary commands if compiling malicious, unescaped, or AI-generated input (Remote Code Execution). Additionally, the subprocess call lacked a timeout, making it vulnerable to infinite compilation loops leading to Denial of Service (DoS) and zombie processes.
**Impact:** A malicious or improperly sanitized input to the cover letter generator could result in arbitrary code execution on the host machine or resource exhaustion causing an outage.
**Fix:**
- Added `-no-shell-escape` to `pdflatex` arguments.
- Added `--pdf-engine-opt=-no-shell-escape` to `pandoc` fallback arguments.
- Implemented `timeout=30` in `process.communicate()` with proper process termination (`process.kill()`) and stream cleanup to prevent zombie processes on timeout.
**Verification:** Ran full test suite via `pytest tests/` which completed successfully. The `tests/test_cover_letter_generator.py` tests executed successfully, ensuring no regressions.

---
*PR created automatically by Jules for task [9354257226934992843](https://jules.google.com/task/9354257226934992843) started by @anchapin*

## Summary by Sourcery

Harden PDF compilation in the cover letter generator to mitigate command injection and denial-of-service risks.

Bug Fixes:
- Disable LaTeX shell escape when invoking pdflatex and the pandoc xelatex engine to prevent command injection during PDF generation.
- Add timeouts and proper process termination for pdflatex and pandoc invocations to avoid hangs and zombie processes during PDF compilation.