### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix LaTeX/Pandoc RCE and infinite compilation loop

### DIFF
--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -771,12 +771,18 @@ Return ONLY valid JSON, nothing else."""
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
+
             if process.returncode == 0 or output_path.exists():
                 pdf_created = True
         except (subprocess.CalledProcessError, FileNotFoundError):
@@ -787,11 +793,24 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        [
+                            "pandoc",
+                            str(tex_path),
+                            "-o",
+                            str(output_path),
+                            "--pdf-engine=xelatex",
+                            "--pdf-engine-opt=-no-shell-escape",
+                        ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )
-                    stdout, stderr = process.communicate()
+                    try:
+                        stdout, stderr = process.communicate(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        stdout, stderr = process.communicate()
+                        raise RuntimeError("PDF compilation timed out")
+
                     if process.returncode == 0 or output_path.exists():
                         pdf_created = True
                 except (subprocess.CalledProcessError, FileNotFoundError):

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -86,12 +86,17 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
 
             if process.returncode == 0 or output_path.exists():
                 return True
@@ -121,12 +126,24 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                [
+                    "pandoc",
+                    str(tex_path),
+                    "-o",
+                    str(output_path),
+                    "--pdf-engine=xelatex",
+                    "--pdf-engine-opt=-no-shell-escape",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
 
             if process.returncode == 0 or output_path.exists():
                 return True


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `pdflatex` and `pandoc` commands in `cli/pdf/converter.py` and `cli/generators/cover_letter_generator.py` were executing without the `-no-shell-escape` flag. This left the application vulnerable to Remote Code Execution (RCE) via shell escape commands embedded in LaTeX input (e.g., `\write18`). Furthermore, `subprocess.communicate()` calls lacked a `timeout`, leading to potential Denial of Service (DoS) due to hanging processes or infinite compilation loops.
🎯 Impact: Attackers could execute arbitrary shell commands on the server during PDF generation. Malicious or malformed inputs could also hang the process indefinitely, consuming server resources and causing DoS.
🔧 Fix:
- Added the `-no-shell-escape` flag to all `pdflatex` command executions.
- Added the `--pdf-engine-opt=-no-shell-escape` flag to all `pandoc` command executions.
- Added a `timeout=30` argument to all `subprocess.communicate()` calls.
- Handled `subprocess.TimeoutExpired` by terminating the process with `.kill()`, cleaning up with `.communicate()`, and raising a safe `RuntimeError`.
✅ Verification: Ran the full test suite (`python -m pytest tests/`), and all 681 tests passed successfully, including specific assertions in `tests/test_pdf_security.py`.

---
*PR created automatically by Jules for task [7772825152343095644](https://jules.google.com/task/7772825152343095644) started by @anchapin*

## Summary by Sourcery

Harden PDF generation against code execution and hangs by tightening LaTeX/pandoc invocation and process handling.

Bug Fixes:
- Disable LaTeX shell escapes for all pdflatex and pandoc-based PDF generation to prevent remote code execution from untrusted input.
- Add timeouts and robust timeout handling around LaTeX and pandoc subprocesses to avoid infinite compilation loops and hanging PDF generation.