### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix LaTeX RCE and DoS vulnerabilities

### DIFF
--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -771,15 +771,20 @@ Return ONLY valid JSON, nothing else."""
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
             if process.returncode == 0 or output_path.exists():
                 pdf_created = True
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (subprocess.CalledProcessError, FileNotFoundError, RuntimeError):
             # Check if PDF was created anyway
             if output_path.exists():
                 pdf_created = True
@@ -787,14 +792,26 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        [
+                            "pandoc",
+                            str(tex_path),
+                            "-o",
+                            str(output_path),
+                            "--pdf-engine=xelatex",
+                            "--pdf-engine-opt=-no-shell-escape",
+                        ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )
-                    stdout, stderr = process.communicate()
+                    try:
+                        stdout, stderr = process.communicate(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        stdout, stderr = process.communicate()
+                        raise RuntimeError("PDF compilation timed out")
                     if process.returncode == 0 or output_path.exists():
                         pdf_created = True
-                except (subprocess.CalledProcessError, FileNotFoundError):
+                except (subprocess.CalledProcessError, FileNotFoundError, RuntimeError):
                     pass
 
         if not pdf_created or not output_path.exists():

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -86,16 +86,21 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
 
             if process.returncode == 0 or output_path.exists():
                 return True
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (subprocess.CalledProcessError, FileNotFoundError, RuntimeError):
             # Check if PDF was created anyway (pdflatex returns non-zero for warnings)
             if output_path.exists():
                 return True
@@ -121,16 +126,28 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                [
+                    "pandoc",
+                    str(tex_path),
+                    "-o",
+                    str(output_path),
+                    "--pdf-engine=xelatex",
+                    "--pdf-engine-opt=-no-shell-escape",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
 
             if process.returncode == 0 or output_path.exists():
                 return True
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (subprocess.CalledProcessError, FileNotFoundError, RuntimeError):
             pass
 
         return False


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: LaTeX compilation is vulnerable to Remote Code Execution (RCE) via the `\write18` feature which allows execution of arbitrary system commands from within the LaTeX document. It is also vulnerable to Denial of Service (DoS) via crafted input that causes infinite compilation loops.
🎯 Impact: An attacker who can supply malicious LaTeX input (or resume input that translates to malicious LaTeX) could execute arbitrary commands on the host server or crash the process via infinite loops.
🔧 Fix: Added `-no-shell-escape` flags to `pdflatex` and `--pdf-engine-opt=-no-shell-escape` for `pandoc` across both `cli/pdf/converter.py` and `cli/generators/cover_letter_generator.py`. Implemented a 30-second timeout on all `subprocess.communicate()` calls with proper zombie process reaping.
✅ Verification: Ran `pip install -e ".[ai,dev]"` and `python -m pytest` which passed all 681 tests. Verified that flags and timeouts are present. Tested locally by inspecting the updated source files.

---
*PR created automatically by Jules for task [7754131979389897966](https://jules.google.com/task/7754131979389897966) started by @anchapin*

## Summary by Sourcery

Harden LaTeX-based PDF generation against remote code execution and denial-of-service conditions.

Bug Fixes:
- Disable LaTeX shell escapes for pdflatex and pandoc-based PDF generation to prevent command execution from untrusted documents.
- Add timeouts to LaTeX and pandoc subprocess calls and handle timeouts gracefully to avoid hangs and potential denial-of-service during PDF compilation.