### PR TITLE
⚡ Bolt: [performance improvement] Pre-compile regex patterns in JobParser

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-02-18 - Regex Pre-compilation in Hot Paths
 **Learning:** Re-compiling regexes inside a frequently called function (like `latex_escape` which runs for every string) creates significant overhead. Pre-compiling them at module level yielded a ~3.2x speedup.
 **Action:** Always look for regex compilations inside loops or frequently called functions and move them to module level constants.
+
+## 2025-02-23 - BeautifulSoup Regex Searching
+**Learning:** When using BeautifulSoup `soup.find(string=...)`, passing a pre-compiled regex `re.Pattern` object is valid at runtime but can cause `mypy` overload errors with older stubs.
+**Action:** Append `# type: ignore[call-overload]` to the `soup.find()` call when passing a compiled regex pattern object.

--- a/cli/integrations/job_parser.py
+++ b/cli/integrations/job_parser.py
@@ -19,7 +19,7 @@ import json
 import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from bs4 import BeautifulSoup, Tag
 
@@ -72,6 +72,43 @@ class JobDetails:
             description=data.get("description"),
             benefits=data.get("benefits", []),
         )
+
+
+# Pre-compiled regex patterns for performance optimization
+_SALARY_PATTERNS = [
+    re.compile(r"\$[\d,]+(?:\s*[-–to]+\s*\$[\d,]+)?", re.IGNORECASE),  # $100k - $150k
+    re.compile(r"\$[\d,]+k(?:\s*[-–to]+\s*\$[\d,]+k)?", re.IGNORECASE),  # $100k - $150k
+    re.compile(r"[\d,]+k(?:\s*[-–to]+\s*[\d,]+k)", re.IGNORECASE),  # 100k - 150k
+    re.compile(r"(?:salary|pay|compensation)[:\s]*(\$[^<>\n]+)", re.IGNORECASE),  # Salary: $X
+    re.compile(r"(?:per|/)\s*(?:year|annum)[:\s]*(\$[^<>\n]+)", re.IGNORECASE),  # per year: $X
+]
+
+_JOB_TYPE_PATTERNS = [
+    re.compile(
+        r"\b(full[- ]?time|part[- ]?time|contract|freelance|intern|temporary)\b", re.IGNORECASE
+    ),
+    re.compile(r"\b(permanent|fixed[- ]?term)\b", re.IGNORECASE),
+]
+
+_EXPERIENCE_LEVEL_PATTERNS = [
+    re.compile(
+        r"\b(entry[- ]?level|junior|mid[- ]?level|senior|staff|principal|lead)\b", re.IGNORECASE
+    ),
+    re.compile(r"\b(associate|vice[- ]?president|director|executive)\b", re.IGNORECASE),
+]
+
+_REQ_SECTION_PATTERN = re.compile(
+    r"(?:^|\n)\s*(requirements?|qualifications?|what we(?:'re)? looking for|what you(?:'ll)? bring)\s*:?\s*\n",
+    re.IGNORECASE,
+)
+
+_RESP_SECTION_PATTERN = re.compile(
+    r"(?:^|\n)\s*(responsibilities?|duties?|what you(?:'ll)? do|your impact|key responsibilities)\s*:?\s*\n",
+    re.IGNORECASE,
+)
+
+_REQ_HEADING_PATTERN = re.compile(r"requirements|qualifications|skills", re.IGNORECASE)
+_RESP_HEADING_PATTERN = re.compile(r"responsibilities|duties|what you", re.IGNORECASE)
 
 
 class JobParser:
@@ -450,8 +487,8 @@ class JobParser:
         requirements = []
         req_heading = soup.find(
             ["h1", "h2", "h3", "h4", "h5", "h6"],
-            string=re.compile(r"requirements|qualifications|skills", re.IGNORECASE),
-        )
+            string=_REQ_HEADING_PATTERN,
+        )  # type: ignore[call-overload]
         if req_heading:
             # Get the next sibling element(s) containing the list
             next_elem = req_heading.find_next_sibling(["ul", "ol", "div", "p"])
@@ -465,8 +502,8 @@ class JobParser:
         responsibilities = []
         resp_heading = soup.find(
             ["h1", "h2", "h3", "h4", "h5", "h6"],
-            string=re.compile(r"responsibilities|duties|what you", re.IGNORECASE),
-        )
+            string=_RESP_HEADING_PATTERN,
+        )  # type: ignore[call-overload]
         if resp_heading:
             next_elem = resp_heading.find_next_sibling(["ul", "ol", "div", "p"])
             if next_elem:
@@ -529,7 +566,7 @@ class JobParser:
                 return elem
         return None
 
-    def _extract_text_by_pattern(self, text: str, pattern: str) -> Optional[str]:
+    def _extract_text_by_pattern(self, text: str, pattern: Union[str, re.Pattern]) -> Optional[str]:
         """
         Extract text using regex pattern.
 
@@ -540,7 +577,11 @@ class JobParser:
         Returns:
             Extracted text or None
         """
-        match = re.search(pattern, text, re.IGNORECASE)
+        if isinstance(pattern, re.Pattern):
+            match = pattern.search(text)
+        else:
+            match = re.search(pattern, text, re.IGNORECASE)
+
         if match:
             return match.group(1).strip()
         return None
@@ -555,17 +596,8 @@ class JobParser:
         Returns:
             Salary string or None
         """
-        # Common salary patterns
-        patterns = [
-            r"\$[\d,]+(?:\s*[-–to]+\s*\$[\d,]+)?",  # $100k - $150k
-            r"\$[\d,]+k(?:\s*[-–to]+\s*\$[\d,]+k)?",  # $100k - $150k
-            r"[\d,]+k(?:\s*[-–to]+\s*[\d,]+k)",  # 100k - 150k
-            r"(?:salary|pay|compensation)[:\s]*(\$[^<>\n]+)",  # Salary: $X
-            r"(?:per|/)\s*(?:year|annum)[:\s]*(\$[^<>\n]+)",  # per year: $X
-        ]
-
-        for pattern in patterns:
-            match = re.search(pattern, text, re.IGNORECASE)
+        for pattern in _SALARY_PATTERNS:
+            match = pattern.search(text)
             if match:
                 salary = match.group(0) if match.lastindex is None else match.group(1)
                 # Clean up the salary string
@@ -592,14 +624,9 @@ class JobParser:
         if not description:
             return requirements, responsibilities
 
-        # Find section boundaries using regex
-        # Match section headers with optional colon, at start of line or after newline
-        req_pattern = r"(?:^|\n)\s*(requirements?|qualifications?|what we(?:'re)? looking for|what you(?:'ll)? bring)\s*:?\s*\n"
-        resp_pattern = r"(?:^|\n)\s*(responsibilities?|duties?|what you(?:'ll)? do|your impact|key responsibilities)\s*:?\s*\n"
-
         # Find positions of section headers
-        req_match = re.search(req_pattern, description, re.IGNORECASE)
-        resp_match = re.search(resp_pattern, description, re.IGNORECASE)
+        req_match = _REQ_SECTION_PATTERN.search(description)
+        resp_match = _RESP_SECTION_PATTERN.search(description)
 
         req_start = req_match.start() if req_match else -1
         resp_start = resp_match.start() if resp_match else -1
@@ -805,13 +832,8 @@ class JobParser:
         Returns:
             Job type string or None
         """
-        patterns = [
-            r"\b(full[- ]?time|part[- ]?time|contract|freelance|intern|temporary)\b",
-            r"\b(permanent|fixed[- ]?term)\b",
-        ]
-
-        for pattern in patterns:
-            match = re.search(pattern, html, re.IGNORECASE)
+        for pattern in _JOB_TYPE_PATTERNS:
+            match = pattern.search(html)
             if match:
                 return match.group(1).lower().replace("-", "-")
 
@@ -827,13 +849,8 @@ class JobParser:
         Returns:
             Experience level string or None
         """
-        patterns = [
-            r"\b(entry[- ]?level|junior|mid[- ]?level|senior|staff|principal|lead)\b",
-            r"\b(associate|vice[- ]?president|director|executive)\b",
-        ]
-
-        for pattern in patterns:
-            match = re.search(pattern, html, re.IGNORECASE)
+        for pattern in _EXPERIENCE_LEVEL_PATTERNS:
+            match = pattern.search(html)
             if match:
                 return match.group(1).lower().replace("-", "-")
 


### PR DESCRIPTION
💡 What: Hoisted inline regular expressions used in `JobParser` methods (like salary parsing, job type extraction, etc.) to module-level, pre-compiled constants using `re.compile()`. Handled mypy stubs using `# type: ignore[call-overload]` for BeautifulSoup `.find()` invocations.
🎯 Why: Inside the `JobParser` from `cli/integrations/job_parser.py`, multiple `re.search` calls were made with string patterns directly inside loops, causing string compilation overhead per call. 
📊 Impact: Expected to reduce execution time for job posting parsing loops slightly, preventing redundant CPU cycles compiling regular expressions on every page scraped/parsed.
🔬 Measurement: Verify using `make test` which exercises `TestParseJobPostingFunction` and `test_job_parser_integration.py` tests.

---
*PR created automatically by Jules for task [4102099980227595152](https://jules.google.com/task/4102099980227595152) started by @anchapin*

## Summary by Sourcery

Pre-compile regular expression patterns used in JobParser to reduce repeated compilation overhead and update related parsing helpers accordingly.

Enhancements:
- Hoist commonly used salary, job type, experience level, and section-detection regexes to module-level compiled patterns and reuse them across parsing methods.
- Update JobParser helpers to accept and work with compiled regex Pattern instances where appropriate, including section extraction and generic text extraction.
- Document learnings and conventions around regex pre-compilation and BeautifulSoup regex usage in the .jules/bolt.md knowledge file, including guidance on mypy type ignores for soup.find calls with compiled patterns.