### PR TITLE
⚡ Bolt: Offload blocking API calls in FastAPI endpoints

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-02-18 - Regex Pre-compilation in Hot Paths
 **Learning:** Re-compiling regexes inside a frequently called function (like `latex_escape` which runs for every string) creates significant overhead. Pre-compiling them at module level yielded a ~3.2x speedup.
 **Action:** Always look for regex compilations inside loops or frequently called functions and move them to module level constants.
+## 2025-02-18 - Async Endpoint Offloading
+**Learning:** Using synchronous, blocking operations (like file I/O or PDF generation) directly inside `async def` route handlers in FastAPI can cause event loop starvation and significantly degrade throughput under load.
+**Action:** When a route handler is defined as `async def`, any blocking code should be explicitly offloaded to a worker thread pool using `anyio.to_thread.run_sync`.

--- a/api/main.py
+++ b/api/main.py
@@ -1,8 +1,10 @@
 import logging
 import os
 import tempfile
+from functools import partial
 from pathlib import Path
 
+import anyio
 import yaml
 from fastapi import FastAPI, HTTPException, Response, Security
 from fastapi.middleware.cors import CORSMiddleware
@@ -171,13 +173,19 @@ async def render_pdf(request: ResumeRequest):
             # We output to a temp file
             output_pdf = temp_path / "output.pdf"
 
-            generator.generate(variant=request.variant, output_format="pdf", output_path=output_pdf)
+            generate_call = partial(
+                generator.generate,
+                variant=request.variant,
+                output_format="pdf",
+                output_path=output_pdf,
+            )
+            await anyio.to_thread.run_sync(generate_call)
 
-            if not output_pdf.exists():
+            if not await anyio.to_thread.run_sync(output_pdf.exists):
                 raise HTTPException(status_code=500, detail="PDF generation failed")
 
             # Read bytes
-            content = output_pdf.read_bytes()
+            content = await anyio.to_thread.run_sync(output_pdf.read_bytes)
 
             return Response(
                 content=content,
@@ -323,11 +331,12 @@ async def generate_cover_letter(request: CoverLetterRequest):
 
                 # Compile LaTeX to PDF
                 pdf_path = temp_path / "cover-letter.pdf"
-                if generator._compile_pdf(pdf_path, outputs["pdf"]):
+                compile_call = partial(generator._compile_pdf, pdf_path, outputs["pdf"])
+                compile_success = await anyio.to_thread.run_sync(compile_call)
+                if compile_success:
                     import base64
 
-                    with open(pdf_path, "rb") as f:
-                        pdf_bytes = f.read()
+                    pdf_bytes = await anyio.to_thread.run_sync(pdf_path.read_bytes)
                     return {
                         "content": base64.b64encode(pdf_bytes).decode("utf-8"),
                         "format": "pdf",
@@ -560,12 +569,15 @@ async def render_resume_pdf(resume_id: str, variant: str = "base"):
             generator = TemplateGenerator(yaml_path=resume_yaml_path)
             output_pdf = temp_path / "output.pdf"
 
-            generator.generate(variant=variant, output_format="pdf", output_path=output_pdf)
+            generate_call = partial(
+                generator.generate, variant=variant, output_format="pdf", output_path=output_pdf
+            )
+            await anyio.to_thread.run_sync(generate_call)
 
-            if not output_pdf.exists():
+            if not await anyio.to_thread.run_sync(output_pdf.exists):
                 raise HTTPException(status_code=500, detail="PDF generation failed")
 
-            content = output_pdf.read_bytes()
+            content = await anyio.to_thread.run_sync(output_pdf.read_bytes)
 
             return Response(
                 content=content,


### PR DESCRIPTION
💡 What: Offloaded synchronous blocking operations (`generator.generate`, `generator._compile_pdf`, file reads, and file system checks) within the `render_pdf`, `generate_cover_letter`, and `render_resume_pdf` asynchronous endpoints in `api/main.py` using `anyio.to_thread.run_sync`.
🎯 Why: FastAPI handles asynchronous routes concurrently within a single-threaded event loop. Executing blocking operations, such as PDF compilation and file read/writes, directly in an `async def` handler halts the event loop, causing other requests to wait. This causes severe throughput degradation. Offloading such heavy tasks to a background thread pool resolves event loop starvation.
📊 Impact: Expected to greatly improve concurrency under load by keeping the main event loop free while heavy operations are executed concurrently by threads.
🔬 Measurement: Verify with high-concurrency request benchmarks. The optimization does not change any return parameters, but you can examine latency metrics with an increase in API usage load.

---
*PR created automatically by Jules for task [11471079969465657249](https://jules.google.com/task/11471079969465657249) started by @anchapin*

## Summary by Sourcery

Offload blocking PDF generation and file I/O from asynchronous FastAPI endpoints to background threads to prevent event loop blocking and improve concurrency.

Enhancements:
- Run PDF generation, PDF compilation, and file system checks in `render_pdf`, `generate_cover_letter`, and `render_resume_pdf` via `anyio.to_thread.run_sync` instead of directly in async handlers.
- Document the guideline to offload blocking operations from async FastAPI routes into worker thread pools in the performance notes.

Documentation:
- Extend the Bolt performance notes with guidance on offloading blocking work from async FastAPI endpoints using `anyio.to_thread.run_sync`.