### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix PDF compilation RCE vulnerabilities

### DIFF
--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -792,7 +792,14 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex", "--pdf-engine-opt=-no-shell-escape"],
+                        [
+                            "pandoc",
+                            str(tex_path),
+                            "-o",
+                            str(output_path),
+                            "--pdf-engine=xelatex",
+                            "--pdf-engine-opt=-no-shell-escape",
+                        ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )

--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -771,12 +771,17 @@ Return ONLY valid JSON, nothing else."""
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
             if process.returncode == 0 or output_path.exists():
                 pdf_created = True
         except (subprocess.CalledProcessError, FileNotFoundError):
@@ -787,11 +792,16 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex", "--pdf-engine-opt=-no-shell-escape"],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )
-                    stdout, stderr = process.communicate()
+                    try:
+                        stdout, stderr = process.communicate(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        stdout, stderr = process.communicate()
+                        raise RuntimeError("PDF compilation timed out")
                     if process.returncode == 0 or output_path.exists():
                         pdf_created = True
                 except (subprocess.CalledProcessError, FileNotFoundError):

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -86,12 +86,17 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
 
             if process.returncode == 0 or output_path.exists():
                 return True
@@ -121,12 +126,17 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex", "--pdf-engine-opt=-no-shell-escape"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
 
             if process.returncode == 0 or output_path.exists():
                 return True

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -126,7 +126,14 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex", "--pdf-engine-opt=-no-shell-escape"],
+                [
+                    "pandoc",
+                    str(tex_path),
+                    "-o",
+                    str(output_path),
+                    "--pdf-engine=xelatex",
+                    "--pdf-engine-opt=-no-shell-escape",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `PDFConverter` and `CoverLetterGenerator` used `subprocess.Popen` to compile LaTeX into PDFs via `pdflatex` or `pandoc` without the `-no-shell-escape` flag and without timeouts, which could allow malicious user input to execute arbitrary shell commands via `\write18` or cause infinite loops leading to DoS.
🎯 Impact: Attackers could gain Remote Code Execution (RCE) on the server rendering PDFs or exhaust server resources through infinite compilation loops.
🔧 Fix: Added `-no-shell-escape` for `pdflatex` and `--pdf-engine-opt=-no-shell-escape` for `pandoc`. Added a 30-second timeout `process.communicate(timeout=30)` along with a safe fallback mechanism to kill processes gracefully when timeouts occur.
✅ Verification: Ran unit tests `python -m pytest tests/` which successfully passed all 681 test cases including the `TestPDFSecurity` unit tests simulating timeout handling.

---
*PR created automatically by Jules for task [6014218835967230817](https://jules.google.com/task/6014218835967230817) started by @anchapin*

## Summary by Sourcery

Harden PDF compilation to prevent remote code execution and runaway LaTeX processes in both the cover letter generator and generic PDF converter.

Bug Fixes:
- Disable LaTeX shell escape in pdflatex and pandoc-based PDF compilation to close RCE vectors in PDF generation.
- Add timeouts and graceful process termination for LaTeX and pandoc PDF compilation to prevent infinite or long-running builds from causing resource exhaustion.