### PR TITLE
⚡ Bolt: Offload blocking I/O to threads in async routes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-02-18 - Regex Pre-compilation in Hot Paths
 **Learning:** Re-compiling regexes inside a frequently called function (like `latex_escape` which runs for every string) creates significant overhead. Pre-compiling them at module level yielded a ~3.2x speedup.
 **Action:** Always look for regex compilations inside loops or frequently called functions and move them to module level constants.
+
+## 2024-05-22 - FastApi Event Loop Starvation
+**Learning:** Blocking synchronous I/O operations (like reading files or heavy processing like PDF compilation) inside FastAPI async routes block the main thread and cause event loop starvation, leading to performance degradation and unresponsiveness under load.
+**Action:** Always wrap synchronous and blocking I/O calls inside async routes using `await anyio.to_thread.run_sync()`. For functions with keyword arguments, use `functools.partial()` to wrap the call.

--- a/api/main.py
+++ b/api/main.py
@@ -2,6 +2,8 @@ import logging
 import os
 import tempfile
 from pathlib import Path
+import anyio
+import functools
 
 import yaml
 from fastapi import FastAPI, HTTPException, Response, Security
@@ -171,13 +173,20 @@ async def render_pdf(request: ResumeRequest):
             # We output to a temp file
             output_pdf = temp_path / "output.pdf"
 
-            generator.generate(variant=request.variant, output_format="pdf", output_path=output_pdf)
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    generator.generate,
+                    variant=request.variant,
+                    output_format="pdf",
+                    output_path=output_pdf,
+                )
+            )
 
-            if not output_pdf.exists():
+            if not await anyio.to_thread.run_sync(output_pdf.exists):
                 raise HTTPException(status_code=500, detail="PDF generation failed")
 
             # Read bytes
-            content = output_pdf.read_bytes()
+            content = await anyio.to_thread.run_sync(output_pdf.read_bytes)
 
             return Response(
                 content=content,
@@ -215,8 +224,12 @@ async def tailor_resume(request: TailorRequest):
         # We pass None for yaml_path as we use direct data
         generator = AIGenerator(yaml_path=None, config=config)
 
-        tailored_data = generator.tailor_data(
-            resume_data=request.resume_data, job_description=request.job_description
+        tailored_data = await anyio.to_thread.run_sync(
+            functools.partial(
+                generator.tailor_data,
+                resume_data=request.resume_data,
+                job_description=request.job_description,
+            )
         )
 
         return tailored_data
@@ -248,7 +261,9 @@ async def ats_check(request: ATSRequest):
 
         # Generate ATS report directly from resume data
         generator = ATSGenerator(config=config, resume_data=request.resume_data)
-        report = generator.generate_report(request.job_description, request.variant)
+        report = await anyio.to_thread.run_sync(
+            functools.partial(generator.generate_report, request.job_description, request.variant)
+        )
 
         # Convert to JSON-serializable format
         result = {
@@ -300,11 +315,14 @@ async def generate_cover_letter(request: CoverLetterRequest):
 
         # Generate cover letter (always use non-interactive for API)
         # The provided answers will be used as context by the AI
-        outputs, job_details = generator.generate_non_interactive(
-            job_description=request.job_description,
-            company_name=request.company_name,
-            variant=request.variant,
-            output_formats=[request.format],
+        outputs, job_details = await anyio.to_thread.run_sync(
+            functools.partial(
+                generator.generate_non_interactive,
+                job_description=request.job_description,
+                company_name=request.company_name,
+                variant=request.variant,
+                output_formats=[request.format],
+            )
         )
 
         # Return the generated content
@@ -323,11 +341,10 @@ async def generate_cover_letter(request: CoverLetterRequest):
 
                 # Compile LaTeX to PDF
                 pdf_path = temp_path / "cover-letter.pdf"
-                if generator._compile_pdf(pdf_path, outputs["pdf"]):
+                if await anyio.to_thread.run_sync(generator._compile_pdf, pdf_path, outputs["pdf"]):
                     import base64
 
-                    with open(pdf_path, "rb") as f:
-                        pdf_bytes = f.read()
+                    pdf_bytes = await anyio.to_thread.run_sync(pdf_path.read_bytes)
                     return {
                         "content": base64.b64encode(pdf_bytes).decode("utf-8"),
                         "format": "pdf",
@@ -553,19 +570,25 @@ async def render_resume_pdf(resume_id: str, variant: str = "base"):
         converter = JSONResumeConverter()
         yaml_data = converter.json_resume_to_yaml(_resume_storage[resume_id]["json_resume"])
 
-        with open(resume_yaml_path, "w", encoding="utf-8") as f:
-            yaml.dump(yaml_data, f, default_flow_style=False)
+        yaml_str = yaml.dump(yaml_data, default_flow_style=False)
+        await anyio.to_thread.run_sync(
+            functools.partial(resume_yaml_path.write_text, yaml_str, encoding="utf-8")
+        )
 
         try:
             generator = TemplateGenerator(yaml_path=resume_yaml_path)
             output_pdf = temp_path / "output.pdf"
 
-            generator.generate(variant=variant, output_format="pdf", output_path=output_pdf)
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    generator.generate, variant=variant, output_format="pdf", output_path=output_pdf
+                )
+            )
 
-            if not output_pdf.exists():
+            if not await anyio.to_thread.run_sync(output_pdf.exists):
                 raise HTTPException(status_code=500, detail="PDF generation failed")
 
-            content = output_pdf.read_bytes()
+            content = await anyio.to_thread.run_sync(output_pdf.read_bytes)
 
             return Response(
                 content=content,

--- a/api/main.py
+++ b/api/main.py
@@ -1,10 +1,10 @@
+import functools
 import logging
 import os
 import tempfile
 from pathlib import Path
-import anyio
-import functools
 
+import anyio
 import yaml
 from fastapi import FastAPI, HTTPException, Response, Security
 from fastapi.middleware.cors import CORSMiddleware


### PR DESCRIPTION
### 💡 What
Modified `api/main.py` to offload heavy synchronous operations (like PDF generation, AI data generation, and file I/O) to a thread pool using `anyio.to_thread.run_sync()`.

### 🎯 Why
In FastAPI, `async def` routes execute on the main thread's event loop. Calling blocking functions inside these routes pauses the event loop, preventing the server from handling other incoming requests until the blocking operation completes. This leads to severe performance degradation under concurrent load (event loop starvation).

### 📊 Impact
Prevents event loop starvation during heavy operations (like `/v1/resumes/render/pdf` or `/v1/cover-letter/generate`), allowing the API to handle concurrent requests up to the size of the thread pool instead of blocking entirely.

### 🔬 Measurement
Run a load test against `/v1/resumes/render/pdf` with 10 concurrent users. Before this change, the requests would queue sequentially and block all other API interactions. After this change, the requests are processed in parallel and other endpoints (like `/v1/resumes`) remain responsive.

---
*PR created automatically by Jules for task [17788627435282094492](https://jules.google.com/task/17788627435282094492) started by @anchapin*

## Summary by Sourcery

Offload blocking I/O and heavy synchronous processing in FastAPI async routes to a thread pool to avoid event loop starvation and improve concurrency.

Enhancements:
- Wrap PDF generation, AI data generation, and other synchronous processing in async routes using anyio.to_thread.run_sync to prevent blocking the event loop.

Documentation:
- Document the lesson about FastAPI event loop starvation and the practice of wrapping blocking I/O with anyio.to_thread.run_sync in the Bolt learnings log.