### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix PDF compilation security (RCE & Timeout)

### DIFF
--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -771,12 +771,19 @@ Return ONLY valid JSON, nothing else."""
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                pdf_created = False
+                return False
+
             if process.returncode == 0 or output_path.exists():
                 pdf_created = True
         except (subprocess.CalledProcessError, FileNotFoundError):
@@ -787,11 +794,25 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        [
+                            "pandoc",
+                            str(tex_path),
+                            "-o",
+                            str(output_path),
+                            "--pdf-engine=xelatex",
+                            "--pdf-engine-opt=-no-shell-escape",
+                        ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )
-                    stdout, stderr = process.communicate()
+                    try:
+                        stdout, stderr = process.communicate(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        stdout, stderr = process.communicate()
+                        pdf_created = False
+                        return False
+
                     if process.returncode == 0 or output_path.exists():
                         pdf_created = True
                 except (subprocess.CalledProcessError, FileNotFoundError):

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -86,12 +86,17 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                return False
 
             if process.returncode == 0 or output_path.exists():
                 return True
@@ -121,12 +126,24 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                [
+                    "pandoc",
+                    str(tex_path),
+                    "-o",
+                    str(output_path),
+                    "--pdf-engine=xelatex",
+                    "--pdf-engine-opt=-no-shell-escape",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                return False
 
             if process.returncode == 0 or output_path.exists():
                 return True


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The PDF compilation processes in `cli/pdf/converter.py` and `cli/generators/cover_letter_generator.py` executed `pdflatex` and `pandoc` without the `-no-shell-escape` flags, and did not enforce a timeout. This allowed malicious input in the .tex templates to potentially execute arbitrary system commands (RCE via `\write18`) or cause a Denial of Service (DoS) by causing the compiler to hang infinitely.
🎯 **Impact:** An attacker who controls the input or if the system automatically generated LaTeX templates using unverified AI-generated text could execute arbitrary code on the server or make it unavailable.
🔧 **Fix:** Added `-no-shell-escape` flag to the `pdflatex` subprocess call. Added `--pdf-engine-opt=-no-shell-escape` flag to the `pandoc` fallback. Wrapped the `communicate()` call with a 30-second timeout, killing the process and doing final cleanup on `TimeoutExpired`.
✅ **Verification:** Ran `python -m pytest tests/test_pdf_security.py` to ensure the specific flags and timeout handling are correctly implemented and caught. Full test suite ran using `python -m pytest tests` successfully.

---
*PR created automatically by Jules for task [2485556127187373522](https://jules.google.com/task/2485556127187373522) started by @anchapin*

## Summary by Sourcery

Harden PDF compilation against remote code execution and hangs by tightening LaTeX engine invocation and adding execution time limits.

Bug Fixes:
- Disable LaTeX shell escapes for pdflatex and pandoc-based PDF generation to prevent command execution via untrusted templates.
- Enforce a 30-second timeout for all PDF compilation subprocesses and fail gracefully on long-running or stuck processes.