### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix RCE and DoS risks in Cover Letter PDF Compilation

### DIFF
--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -771,12 +771,18 @@ Return ONLY valid JSON, nothing else."""
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
+
             if process.returncode == 0 or output_path.exists():
                 pdf_created = True
         except (subprocess.CalledProcessError, FileNotFoundError):
@@ -787,11 +793,24 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        [
+                            "pandoc",
+                            str(tex_path),
+                            "-o",
+                            str(output_path),
+                            "--pdf-engine=xelatex",
+                            "--pdf-engine-opt=-no-shell-escape",
+                        ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )
-                    stdout, stderr = process.communicate()
+                    try:
+                        stdout, stderr = process.communicate(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        stdout, stderr = process.communicate()
+                        raise RuntimeError("PDF compilation timed out")
+
                     if process.returncode == 0 or output_path.exists():
                         pdf_created = True
                 except (subprocess.CalledProcessError, FileNotFoundError):


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `CoverLetterGenerator._compile_pdf` executed `pdflatex` and `pandoc` without `-no-shell-escape` flags and without subprocess timeouts. This allowed an attacker submitting a malicious LaTeX payload to execute arbitrary shell commands (RCE) or stall the backend via infinite loops.
🎯 Impact: Remote code execution, Denial of service.
🔧 Fix: Added `-no-shell-escape` to both LaTeX engines and implemented a 30 second subprocess timeout using `communicate(timeout=30)` with safe termination inside a try/catch block.
✅ Verification: `python -m pytest tests/test_pdf_security.py` passes successfully.

---
*PR created automatically by Jules for task [11261639235760785875](https://jules.google.com/task/11261639235760785875) started by @anchapin*