### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix RCE and DoS in LaTeX Compilation

### DIFF
--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -771,12 +771,18 @@ Return ONLY valid JSON, nothing else."""
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                return False
+
             if process.returncode == 0 or output_path.exists():
                 pdf_created = True
         except (subprocess.CalledProcessError, FileNotFoundError):
@@ -787,11 +793,17 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex", "--pdf-engine-opt=-no-shell-escape"],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )
-                    stdout, stderr = process.communicate()
+                    try:
+                        stdout, stderr = process.communicate(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        stdout, stderr = process.communicate()
+                        return False
+
                     if process.returncode == 0 or output_path.exists():
                         pdf_created = True
                 except (subprocess.CalledProcessError, FileNotFoundError):

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -86,12 +86,17 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                return False
 
             if process.returncode == 0 or output_path.exists():
                 return True
@@ -121,12 +126,17 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex", "--pdf-engine-opt=-no-shell-escape"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                return False
 
             if process.returncode == 0 or output_path.exists():
                 return True


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: LaTeX compilation was missing the `-no-shell-escape` flag and process timeouts in `cli/pdf/converter.py` and `cli/generators/cover_letter_generator.py`. This would allow malicious LaTeX input (e.g. from generated cover letters or custom resume templates) to execute arbitrary shell commands via `\write18` or intentionally hang the compilation process indefinitely.
🎯 Impact: Remote Code Execution (RCE) on the server and Denial of Service (DoS) due to hanging processes.
🔧 Fix: Added `-no-shell-escape` to `pdflatex` commands, `--pdf-engine-opt=-no-shell-escape` to `pandoc` commands, and wrapped the `subprocess.communicate()` calls in a `timeout=30` block with proper `subprocess.TimeoutExpired` handling.
✅ Verification: Ran `pytest` suite and verified `test_pdf_security.py` passes successfully.

---
*PR created automatically by Jules for task [9980735135992216303](https://jules.google.com/task/9980735135992216303) started by @anchapin*

## Summary by Sourcery

Harden LaTeX-based PDF generation against malicious input by securing shell execution and preventing runaway compilation processes.

Bug Fixes:
- Disable shell command execution in pdflatex and pandoc invocations used for cover letter and generic PDF generation.
- Add execution timeouts and graceful handling for LaTeX and pandoc subprocesses to avoid hanging PDF compilation.