### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing -no-shell-escape flag and timeout in PDF generation

### DIFF
--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -771,12 +771,17 @@ Return ONLY valid JSON, nothing else."""
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+                raise RuntimeError("PDF compilation timed out")
             if process.returncode == 0 or output_path.exists():
                 pdf_created = True
         except (subprocess.CalledProcessError, FileNotFoundError):
@@ -787,11 +792,23 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        [
+                            "pandoc",
+                            str(tex_path),
+                            "-o",
+                            str(output_path),
+                            "--pdf-engine=xelatex",
+                            "--pdf-engine-opt=-no-shell-escape",
+                        ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )
-                    stdout, stderr = process.communicate()
+                    try:
+                        stdout, stderr = process.communicate(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        stdout, stderr = process.communicate()
+                        raise RuntimeError("PDF compilation timed out")
                     if process.returncode == 0 or output_path.exists():
                         pdf_created = True
                 except (subprocess.CalledProcessError, FileNotFoundError):

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -86,12 +86,17 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.communicate()
+                return False
 
             if process.returncode == 0 or output_path.exists():
                 return True
@@ -121,12 +126,24 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                [
+                    "pandoc",
+                    str(tex_path),
+                    "-o",
+                    str(output_path),
+                    "--pdf-engine=xelatex",
+                    "--pdf-engine-opt=-no-shell-escape",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.communicate()
+                return False
 
             if process.returncode == 0 or output_path.exists():
                 return True


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Missing `-no-shell-escape` flag in `pdflatex` and `--pdf-engine-opt=-no-shell-escape` in `pandoc` fallback commands inside `cli/generators/cover_letter_generator.py` and `cli/pdf/converter.py` allowed potential Remote Code Execution (RCE) from untrusted inputs embedded into the `.tex` files. Additionally, the lack of `timeout` arguments could cause process hangs (DoS).
🎯 Impact: An attacker or AI hallucination could inject malicious LaTeX commands (like `\immediate\write18{...}`) into the generated cover letter or PDF conversion that would be executed by the host system. Furthermore, an infinite loop in the TeX compilation could hang the server indefinitely.
🔧 Fix: Added `-no-shell-escape` flags and 30-second timeouts with proper `subprocess.TimeoutExpired` handling and process termination.
✅ Verification: Ran `bandit` and `pytest tests/test_pdf_security.py` successfully. Checked `pytest` test suite to ensure no breakage.

---
*PR created automatically by Jules for task [5092411136245107424](https://jules.google.com/task/5092411136245107424) started by @anchapin*

## Summary by Sourcery

Harden PDF generation against unsafe LaTeX execution and hangs in both cover letter and generic PDF conversion flows.

Bug Fixes:
- Prevent remote code execution by disabling shell escape in pdflatex and pandoc-based PDF generation commands.
- Avoid potential denial-of-service hangs in LaTeX and pandoc compilation by enforcing a 30-second timeout with proper process termination.

Enhancements:
- Align error handling for PDF compilation timeouts to propagate clear failures from both primary and fallback PDF generation paths.