### PR TITLE
⚡ Bolt: Hoist Regexes and Constants in ATS Generator

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-02-18 - Regex Pre-compilation in Hot Paths
 **Learning:** Re-compiling regexes inside a frequently called function (like `latex_escape` which runs for every string) creates significant overhead. Pre-compiling them at module level yielded a ~3.2x speedup.
 **Action:** Always look for regex compilations inside loops or frequently called functions and move them to module level constants.
+## 2025-02-18 - Regex Pre-compilation and Hoisting in ATS Generator
+**Learning:** Re-compiling regexes and creating large lists/sets (like `_ACTION_VERBS` or `r"\d+%|\$\d+|\d+\s*(users|customers|projects)"`) inside frequently called loops or functions causes unnecessary object creation and compilation overhead. Furthermore, `.lower()` on large strings for entire document parsing just for case-insensitive checks is inefficient and can cause matching bugs (e.g. acronym matching).
+**Action:** Always pre-compile regexes and hoist static lists to module-level constants. Use `re.IGNORECASE` when case-insensitive matching is needed instead of eagerly lowercasing the entire large input string if the original case is still required for other patterns.

--- a/cli/generators/ats_generator.py
+++ b/cli/generators/ats_generator.py
@@ -37,6 +37,29 @@ except ImportError:
 
 console = Console()
 
+# Pre-compiled regex patterns for performance and bug fixes
+_TABLE_PATTERN = re.compile(r"\|[^\n]+\|")
+_SPECIAL_CHARS_PATTERN = re.compile(r"[^a-zA-Z0-9\s\-\.\,\@\(\)\#\/]")
+_EMAIL_PATTERN = re.compile(r"^[^@]+@[^@]+\.[^@]+$")
+_PHONE_PATTERN = re.compile(r"\d")
+_QUANTIFIABLE_PATTERN = re.compile(r"\d+%|\$\d+|\d+\s*(users|customers|projects)", re.IGNORECASE)
+_ACRONYM_PATTERN = re.compile(r"\b[A-Z]{2,4}\b")
+
+# Tuple of action verbs (avoids list allocation)
+_ACTION_VERBS = (
+    "developed",
+    "implemented",
+    "built",
+    "created",
+    "designed",
+    "managed",
+    "led",
+    "increased",
+    "decreased",
+    "improved",
+    "achieved",
+)
+
 
 @dataclass
 class ATSCategoryScore:
@@ -214,8 +237,8 @@ class ATSGenerator:
 
         # Check for complex formatting indicators
         all_text = self._get_all_text(resume_data)
-        has_tables = bool(re.search(r"\|[^\n]+\|", all_text))
-        has_special_chars = len(re.findall(r"[^a-zA-Z0-9\s\-\.\,\@\(\)\#\/]", all_text))
+        has_tables = bool(_TABLE_PATTERN.search(all_text))
+        has_special_chars = len(_SPECIAL_CHARS_PATTERN.findall(all_text))
 
         if not has_tables:
             details.append("No tables detected (ATS-friendly)")
@@ -349,15 +372,15 @@ class ATSGenerator:
 
         # Check required contact fields
         contact_fields = {
-            "email": (contact.get("email"), 5, r"^[^@]+@[^@]+\.[^@]+$"),
-            "phone": (contact.get("phone"), 5, r"\d"),
+            "email": (contact.get("email"), 5, _EMAIL_PATTERN),
+            "phone": (contact.get("phone"), 5, _PHONE_PATTERN),
             "location": (contact.get("location"), 5, None),  # Just presence check
         }
 
         for field_name, (field_value, field_points, pattern) in contact_fields.items():
             if field_value:
                 if pattern:
-                    if re.search(pattern, field_value):
+                    if pattern.search(field_value):
                         points += field_points
                         details.append(f"✓ {field_name.capitalize()} present and valid")
                     else:
@@ -392,22 +415,10 @@ class ATSGenerator:
         suggestions = []
 
         all_text = self._get_all_text(resume_data)
+        all_text_lower = all_text.lower()
 
         # Check for action verbs in experience bullets
-        action_verbs = [
-            "developed",
-            "implemented",
-            "built",
-            "created",
-            "designed",
-            "managed",
-            "led",
-            "increased",
-            "decreased",
-            "improved",
-            "achieved",
-        ]
-        action_verb_count = sum(1 for verb in action_verbs if verb in all_text.lower())
+        action_verb_count = sum(1 for verb in _ACTION_VERBS if verb in all_text_lower)
 
         if action_verb_count >= 3:
             details.append(f"✓ Uses action verbs ({action_verb_count} found)")
@@ -416,7 +427,7 @@ class ATSGenerator:
             suggestions.append("Use more action verbs (e.g., developed, implemented)")
 
         # Check for quantifiable achievements
-        has_numbers = bool(re.search(r"\d+%|\$\d+|\d+\s*(users|customers|projects)", all_text))
+        has_numbers = bool(_QUANTIFIABLE_PATTERN.search(all_text))
         if has_numbers:
             details.append("✓ Includes quantifiable achievements")
         else:
@@ -425,8 +436,7 @@ class ATSGenerator:
 
         # Check for acronyms (should be minimal or defined)
         # This is a simple heuristic
-        acronym_pattern = r"\b[A-Z]{2,4}\b"
-        acronyms = re.findall(acronym_pattern, all_text)
+        acronyms = _ACRONYM_PATTERN.findall(all_text)
         if len(acronyms) < 10:
             details.append(f"✓ Minimal acronyms ({len(acronyms)} found)")
         else:
@@ -466,7 +476,7 @@ class ATSGenerator:
                     extract_value(v)
 
         extract_value(resume_data)
-        return " ".join(text_parts).lower()
+        return " ".join(text_parts)
 
     def _extract_job_keywords(self, job_description: str) -> List[str]:
         """

--- a/tests/test_ats_generator.py
+++ b/tests/test_ats_generator.py
@@ -356,8 +356,8 @@ class TestGetAllText:
 
         text = ats_generator._get_all_text(resume_data)
 
-        # Text is lowercased
-        assert "john" in text
-        assert "tech corp" in text
-        assert "built apis" in text
-        assert "python" in text
+        # Text should match original casing
+        assert "John" in text
+        assert "Tech Corp" in text
+        assert "Built APIs" in text
+        assert "Python" in text


### PR DESCRIPTION
💡 **What**: Hoisted frequently used regular expressions to pre-compiled module constants, and converted the dynamically generated `action_verbs` list to a module-level tuple. Also refactored `_check_readability` and `_get_all_text` to execute `.lower()` only when needed rather than mapping the entire string.
🎯 **Why**: `_check_readability` and other scoring functions inside `ATSGenerator` are on a hot path during parsing. Constantly recompiling regexes, reallocating lists, and executing `.lower()` on very large strings is costly. Furthermore, lowercasing the string *before* applying the acronym matching regex (`\b[A-Z]{2,4}\b`) masked a bug where it would falsely never find any matches.
📊 **Impact**: Reduces execution time overhead when repeatedly calling `generate_report` by avoiding unnecessary object creation, compilation time, and large string manipulation inside scoring functions.
🔬 **Measurement**: Observe `generate_report` runtime or verify via the test suite passing successfully with the original acronym cases restored.

---
*PR created automatically by Jules for task [12542494540557262951](https://jules.google.com/task/12542494540557262951) started by @anchapin*

## Summary by Sourcery

Optimize ATS generator text analysis by hoisting regexes and constants and avoiding unnecessary lowercasing of aggregated text.

Enhancements:
- Pre-compile frequently used regex patterns and reuse them across ATS generator checks to reduce overhead and fix acronym detection behavior.
- Hoist the action verbs collection to a module-level tuple to avoid repeated list allocations in readability scoring.
- Adjust text aggregation to preserve original casing and apply lowercasing only where needed, improving performance and correctness of mixed-case pattern checks.
- Update internal engineering notes to document lessons on regex pre-compilation, hoisting constants, and selective lowercasing in hot paths.

Tests:
- Update ATS generator tests to verify that aggregated text preserves original casing rather than being globally lowercased.