### PR TITLE
⚡ Bolt: Offload synchronous API operations to worker threads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2024-05-18 - Offload Synchronous File I/O and PDF Compilation in FastAPI
 **Learning:** FastAPI's async endpoints can suffer from event loop starvation when running blocking synchronous tasks like file I/O operations (`read_bytes()`, `open().read()`, `yaml.dump()`) and heavy subprocess invocations (like `generator.generate()` compiling PDFs via `pdflatex`).
 **Action:** Always wrap these synchronous, blocking operations with `anyio.to_thread.run_sync(functools.partial(...))` within FastAPI routes to offload them to worker threads, preserving the main event loop's responsiveness. When offloading keyword arguments, `functools.partial` is necessary because `anyio.to_thread.run_sync` only accepts positional arguments.
+
+## 2024-05-18 - FastAPI Synchronous Endpoint Concurrency
+**Learning:** In FastAPI, heavy synchronous operations (like PDF compilation and extensive file I/O) running inside `async def` routes block the main `asyncio` event loop, starving requests.
+**Action:** Instead of manually wrapping individual synchronous calls with `anyio.to_thread.run_sync(functools.partial(...))`, simply change the route definition from `async def` to `def`. FastAPI automatically executes standard `def` routes in an external threadpool, solving the bottleneck idiomatically without sacrificing code readability.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-02-18 - Regex Pre-compilation in Hot Paths
 **Learning:** Re-compiling regexes inside a frequently called function (like `latex_escape` which runs for every string) creates significant overhead. Pre-compiling them at module level yielded a ~3.2x speedup.
 **Action:** Always look for regex compilations inside loops or frequently called functions and move them to module level constants.
+
+## 2024-05-18 - Offload Synchronous File I/O and PDF Compilation in FastAPI
+**Learning:** FastAPI's async endpoints can suffer from event loop starvation when running blocking synchronous tasks like file I/O operations (`read_bytes()`, `open().read()`, `yaml.dump()`) and heavy subprocess invocations (like `generator.generate()` compiling PDFs via `pdflatex`).
+**Action:** Always wrap these synchronous, blocking operations with `anyio.to_thread.run_sync(functools.partial(...))` within FastAPI routes to offload them to worker threads, preserving the main event loop's responsiveness. When offloading keyword arguments, `functools.partial` is necessary because `anyio.to_thread.run_sync` only accepts positional arguments.

--- a/api/main.py
+++ b/api/main.py
@@ -2,9 +2,7 @@ import logging
 import os
 import tempfile
 from pathlib import Path
-from functools import partial
 
-import anyio
 import yaml
 from fastapi import FastAPI, HTTPException, Response, Security
 from fastapi.middleware.cors import CORSMiddleware
@@ -142,7 +140,7 @@ async def health_check():
         401: {"description": "Invalid or missing API key"},
     },
 )
-async def get_variants():
+def get_variants():
     config = Config()  # Uses default config path logic
     return config.get("variants")
 
@@ -160,7 +158,7 @@ async def get_variants():
         500: {"description": "PDF generation failed"},
     },
 )
-async def render_pdf(request: ResumeRequest):
+def render_pdf(request: ResumeRequest):
     # Create temp directory for output
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
@@ -173,15 +171,13 @@ async def render_pdf(request: ResumeRequest):
             # We output to a temp file
             output_pdf = temp_path / "output.pdf"
 
-            await anyio.to_thread.run_sync(
-                partial(generator.generate, variant=request.variant, output_format="pdf", output_path=output_pdf)
-            )
+            generator.generate(variant=request.variant, output_format="pdf", output_path=output_pdf)
 
-            if not await anyio.to_thread.run_sync(output_pdf.exists):
+            if not output_pdf.exists():
                 raise HTTPException(status_code=500, detail="PDF generation failed")
 
             # Read bytes
-            content = await anyio.to_thread.run_sync(output_pdf.read_bytes)
+            content = output_pdf.read_bytes()
 
             return Response(
                 content=content,
@@ -211,7 +207,7 @@ async def render_pdf(request: ResumeRequest):
         500: {"description": "Resume tailoring failed"},
     },
 )
-async def tailor_resume(request: TailorRequest):
+def tailor_resume(request: TailorRequest):
     try:
         # Initialize AI Generator
         config = Config()
@@ -219,12 +215,8 @@ async def tailor_resume(request: TailorRequest):
         # We pass None for yaml_path as we use direct data
         generator = AIGenerator(yaml_path=None, config=config)
 
-        tailored_data = await anyio.to_thread.run_sync(
-            partial(
-                generator.tailor_data,
-                resume_data=request.resume_data,
-                job_description=request.job_description
-            )
+        tailored_data = generator.tailor_data(
+            resume_data=request.resume_data, job_description=request.job_description
         )
 
         return tailored_data
@@ -249,16 +241,14 @@ async def tailor_resume(request: TailorRequest):
         500: {"description": "ATS check failed"},
     },
 )
-async def ats_check(request: ATSRequest):
+def ats_check(request: ATSRequest):
     """Check ATS compatibility score for a resume against a job description."""
     try:
         config = Config()
 
         # Generate ATS report directly from resume data
         generator = ATSGenerator(config=config, resume_data=request.resume_data)
-        report = await anyio.to_thread.run_sync(
-            partial(generator.generate_report, request.job_description, request.variant)
-        )
+        report = generator.generate_report(request.job_description, request.variant)
 
         # Convert to JSON-serializable format
         result = {
@@ -300,7 +290,7 @@ async def ats_check(request: ATSRequest):
         500: {"description": "Cover letter generation failed"},
     },
 )
-async def generate_cover_letter(request: CoverLetterRequest):
+def generate_cover_letter(request: CoverLetterRequest):
     """Generate a cover letter for a job application."""
     try:
         config = Config()
@@ -310,14 +300,11 @@ async def generate_cover_letter(request: CoverLetterRequest):
 
         # Generate cover letter (always use non-interactive for API)
         # The provided answers will be used as context by the AI
-        outputs, job_details = await anyio.to_thread.run_sync(
-            partial(
-                generator.generate_non_interactive,
-                job_description=request.job_description,
-                company_name=request.company_name,
-                variant=request.variant,
-                output_formats=[request.format],
-            )
+        outputs, job_details = generator.generate_non_interactive(
+            job_description=request.job_description,
+            company_name=request.company_name,
+            variant=request.variant,
+            output_formats=[request.format],
         )
 
         # Return the generated content
@@ -336,14 +323,11 @@ async def generate_cover_letter(request: CoverLetterRequest):
 
                 # Compile LaTeX to PDF
                 pdf_path = temp_path / "cover-letter.pdf"
-                if await anyio.to_thread.run_sync(partial(generator._compile_pdf, pdf_path, outputs["pdf"])):
+                if generator._compile_pdf(pdf_path, outputs["pdf"]):
                     import base64
 
-                    def _read_pdf():
-                        with open(pdf_path, "rb") as f:
-                            return f.read()
-
-                    pdf_bytes = await anyio.to_thread.run_sync(_read_pdf)
+                    with open(pdf_path, "rb") as f:
+                        pdf_bytes = f.read()
                     return {
                         "content": base64.b64encode(pdf_bytes).decode("utf-8"),
                         "format": "pdf",
@@ -388,7 +372,7 @@ _resume_storage: dict = {}
         401: {"description": "Invalid or missing API key"},
     },
 )
-async def list_resumes():
+def list_resumes():
     """List all stored resumes."""
     resumes = [
         ResumeMetadata(
@@ -416,7 +400,7 @@ async def list_resumes():
         500: {"description": "Resume creation failed"},
     },
 )
-async def create_resume(request: JSONResumeRequest):
+def create_resume(request: JSONResumeRequest):
     """Create a new resume from JSON Resume format."""
     import uuid
     from datetime import datetime
@@ -426,9 +410,7 @@ async def create_resume(request: JSONResumeRequest):
 
         # Convert JSON Resume to YAML format
         converter = JSONResumeConverter()
-        yaml_data = await anyio.to_thread.run_sync(
-            partial(converter.json_resume_to_yaml, request.json_resume, include_variants=True)
-        )
+        yaml_data = converter.json_resume_to_yaml(request.json_resume, include_variants=True)
 
         # Generate a unique ID
         resume_id = str(uuid.uuid4())
@@ -466,7 +448,7 @@ async def create_resume(request: JSONResumeRequest):
         404: {"description": "Resume not found"},
     },
 )
-async def get_resume(resume_id: str):
+def get_resume(resume_id: str):
     """Get a specific resume by ID."""
     if resume_id not in _resume_storage:
         raise HTTPException(status_code=404, detail="Resume not found")
@@ -493,7 +475,7 @@ async def get_resume(resume_id: str):
         500: {"description": "Resume update failed"},
     },
 )
-async def update_resume(resume_id: str, request: JSONResumeRequest):
+def update_resume(resume_id: str, request: JSONResumeRequest):
     """Update an existing resume."""
     from datetime import datetime
 
@@ -534,7 +516,7 @@ async def update_resume(resume_id: str, request: JSONResumeRequest):
         404: {"description": "Resume not found"},
     },
 )
-async def delete_resume(resume_id: str):
+def delete_resume(resume_id: str):
     """Delete a resume by ID."""
     if resume_id not in _resume_storage:
         raise HTTPException(status_code=404, detail="Resume not found")
@@ -556,7 +538,7 @@ async def delete_resume(resume_id: str):
         500: {"description": "PDF generation failed"},
     },
 )
-async def render_resume_pdf(resume_id: str, variant: str = "base"):
+def render_resume_pdf(resume_id: str, variant: str = "base"):
     """Render a stored resume as PDF."""
     if resume_id not in _resume_storage:
         raise HTTPException(status_code=404, detail="Resume not found")
@@ -569,28 +551,21 @@ async def render_resume_pdf(resume_id: str, variant: str = "base"):
         from cli.utils.json_resume_converter import JSONResumeConverter
 
         converter = JSONResumeConverter()
-        yaml_data = await anyio.to_thread.run_sync(
-            partial(converter.json_resume_to_yaml, _resume_storage[resume_id]["json_resume"])
-        )
+        yaml_data = converter.json_resume_to_yaml(_resume_storage[resume_id]["json_resume"])
 
-        def _write_yaml():
-            with open(resume_yaml_path, "w", encoding="utf-8") as f:
-                yaml.dump(yaml_data, f, default_flow_style=False)
-
-        await anyio.to_thread.run_sync(_write_yaml)
+        with open(resume_yaml_path, "w", encoding="utf-8") as f:
+            yaml.dump(yaml_data, f, default_flow_style=False)
 
         try:
             generator = TemplateGenerator(yaml_path=resume_yaml_path)
             output_pdf = temp_path / "output.pdf"
 
-            await anyio.to_thread.run_sync(
-                partial(generator.generate, variant=variant, output_format="pdf", output_path=output_pdf)
-            )
+            generator.generate(variant=variant, output_format="pdf", output_path=output_pdf)
 
-            if not await anyio.to_thread.run_sync(output_pdf.exists):
+            if not output_pdf.exists():
                 raise HTTPException(status_code=500, detail="PDF generation failed")
 
-            content = await anyio.to_thread.run_sync(output_pdf.read_bytes)
+            content = output_pdf.read_bytes()
 
             return Response(
                 content=content,

--- a/api/main.py
+++ b/api/main.py
@@ -2,7 +2,9 @@ import logging
 import os
 import tempfile
 from pathlib import Path
+from functools import partial
 
+import anyio
 import yaml
 from fastapi import FastAPI, HTTPException, Response, Security
 from fastapi.middleware.cors import CORSMiddleware
@@ -171,13 +173,15 @@ async def render_pdf(request: ResumeRequest):
             # We output to a temp file
             output_pdf = temp_path / "output.pdf"
 
-            generator.generate(variant=request.variant, output_format="pdf", output_path=output_pdf)
+            await anyio.to_thread.run_sync(
+                partial(generator.generate, variant=request.variant, output_format="pdf", output_path=output_pdf)
+            )
 
-            if not output_pdf.exists():
+            if not await anyio.to_thread.run_sync(output_pdf.exists):
                 raise HTTPException(status_code=500, detail="PDF generation failed")
 
             # Read bytes
-            content = output_pdf.read_bytes()
+            content = await anyio.to_thread.run_sync(output_pdf.read_bytes)
 
             return Response(
                 content=content,
@@ -215,8 +219,12 @@ async def tailor_resume(request: TailorRequest):
         # We pass None for yaml_path as we use direct data
         generator = AIGenerator(yaml_path=None, config=config)
 
-        tailored_data = generator.tailor_data(
-            resume_data=request.resume_data, job_description=request.job_description
+        tailored_data = await anyio.to_thread.run_sync(
+            partial(
+                generator.tailor_data,
+                resume_data=request.resume_data,
+                job_description=request.job_description
+            )
         )
 
         return tailored_data
@@ -248,7 +256,9 @@ async def ats_check(request: ATSRequest):
 
         # Generate ATS report directly from resume data
         generator = ATSGenerator(config=config, resume_data=request.resume_data)
-        report = generator.generate_report(request.job_description, request.variant)
+        report = await anyio.to_thread.run_sync(
+            partial(generator.generate_report, request.job_description, request.variant)
+        )
 
         # Convert to JSON-serializable format
         result = {
@@ -300,11 +310,14 @@ async def generate_cover_letter(request: CoverLetterRequest):
 
         # Generate cover letter (always use non-interactive for API)
         # The provided answers will be used as context by the AI
-        outputs, job_details = generator.generate_non_interactive(
-            job_description=request.job_description,
-            company_name=request.company_name,
-            variant=request.variant,
-            output_formats=[request.format],
+        outputs, job_details = await anyio.to_thread.run_sync(
+            partial(
+                generator.generate_non_interactive,
+                job_description=request.job_description,
+                company_name=request.company_name,
+                variant=request.variant,
+                output_formats=[request.format],
+            )
         )
 
         # Return the generated content
@@ -323,11 +336,14 @@ async def generate_cover_letter(request: CoverLetterRequest):
 
                 # Compile LaTeX to PDF
                 pdf_path = temp_path / "cover-letter.pdf"
-                if generator._compile_pdf(pdf_path, outputs["pdf"]):
+                if await anyio.to_thread.run_sync(partial(generator._compile_pdf, pdf_path, outputs["pdf"])):
                     import base64
 
-                    with open(pdf_path, "rb") as f:
-                        pdf_bytes = f.read()
+                    def _read_pdf():
+                        with open(pdf_path, "rb") as f:
+                            return f.read()
+
+                    pdf_bytes = await anyio.to_thread.run_sync(_read_pdf)
                     return {
                         "content": base64.b64encode(pdf_bytes).decode("utf-8"),
                         "format": "pdf",
@@ -410,7 +426,9 @@ async def create_resume(request: JSONResumeRequest):
 
         # Convert JSON Resume to YAML format
         converter = JSONResumeConverter()
-        yaml_data = converter.json_resume_to_yaml(request.json_resume, include_variants=True)
+        yaml_data = await anyio.to_thread.run_sync(
+            partial(converter.json_resume_to_yaml, request.json_resume, include_variants=True)
+        )
 
         # Generate a unique ID
         resume_id = str(uuid.uuid4())
@@ -551,21 +569,28 @@ async def render_resume_pdf(resume_id: str, variant: str = "base"):
         from cli.utils.json_resume_converter import JSONResumeConverter
 
         converter = JSONResumeConverter()
-        yaml_data = converter.json_resume_to_yaml(_resume_storage[resume_id]["json_resume"])
+        yaml_data = await anyio.to_thread.run_sync(
+            partial(converter.json_resume_to_yaml, _resume_storage[resume_id]["json_resume"])
+        )
 
-        with open(resume_yaml_path, "w", encoding="utf-8") as f:
-            yaml.dump(yaml_data, f, default_flow_style=False)
+        def _write_yaml():
+            with open(resume_yaml_path, "w", encoding="utf-8") as f:
+                yaml.dump(yaml_data, f, default_flow_style=False)
+
+        await anyio.to_thread.run_sync(_write_yaml)
 
         try:
             generator = TemplateGenerator(yaml_path=resume_yaml_path)
             output_pdf = temp_path / "output.pdf"
 
-            generator.generate(variant=variant, output_format="pdf", output_path=output_pdf)
+            await anyio.to_thread.run_sync(
+                partial(generator.generate, variant=variant, output_format="pdf", output_path=output_pdf)
+            )
 
-            if not output_pdf.exists():
+            if not await anyio.to_thread.run_sync(output_pdf.exists):
                 raise HTTPException(status_code=500, detail="PDF generation failed")
 
-            content = output_pdf.read_bytes()
+            content = await anyio.to_thread.run_sync(output_pdf.read_bytes)
 
             return Response(
                 content=content,


### PR DESCRIPTION
**💡 What:** We wrapped heavy blocking synchronous operations (such as file reading/writing, PDF compilation, and heavy string processing) within the FastAPI route handlers (`api/main.py`) using `anyio.to_thread.run_sync` and `functools.partial`.
**🎯 Why:** FastAPI uses an `asyncio` event loop. Running long blocking, synchronous functions inside `async def` routes stalls the event loop, causing request starvation and severely limiting the concurrency and throughput of the API server. Offloading them to a worker thread pool keeps the main loop responsive.
**📊 Impact:** Eliminates main thread blocking during I/O and PDF compilations, dramatically increasing server concurrency and throughput under load.
**🔬 Measurement:** The test suite passes fully, and the endpoints continue to behave as expected. You can verify the behavior by sending concurrent requests to the `/v1/render/pdf` or `/v1/cover-letter` endpoints and noting the improved handling compared to sequential blocking processing.

---
*PR created automatically by Jules for task [2885066603634316720](https://jules.google.com/task/2885066603634316720) started by @anchapin*

## Summary by Sourcery

Offload blocking file I/O, PDF generation, and heavy synchronous processing in FastAPI endpoints to background worker threads to prevent event loop starvation and improve concurrency.

Enhancements:
- Wrap PDF generation, tailoring, ATS report generation, cover letter generation, JSON resume conversion, and related file operations in `anyio.to_thread.run_sync` to run them in worker threads.
- Adjust PDF existence checks and file read/write operations to execute asynchronously via worker threads while preserving existing API behavior.
- Document the performance lesson and best practice for offloading synchronous operations in FastAPI within `.jules/bolt.md`.