### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix RCE in PDF compilation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** The `CoverLetterGenerator` used a standard Jinja2 environment (intended for HTML/XML or plain text) to render LaTeX templates. This allowed malicious user input (or AI hallucinations) containing LaTeX control characters (e.g., `\input{...}`) to be injected directly into the LaTeX source, leading to potential Local File Inclusion (LFI) or other exploits.
 **Learning:** Jinja2's default `autoescape` is context-aware based on file extensions, but usually only for HTML/XML. It does NOT automatically escape LaTeX special characters. Relying on manual filters (like `| latex_escape`) in templates is error-prone and brittle, as developers might forget to apply them to every variable.
 **Prevention:** Always use a dedicated Jinja2 environment for LaTeX generation that enforces auto-escaping via a `finalize` hook (e.g., `tex_env.finalize = latex_escape`). This ensures *all* variable output is sanitized by default, providing defense-in-depth even if the template author forgets explicit filters.
+## 2026-06-07 - [CRITICAL] Prevent RCE in PDF compilation
+**Vulnerability:** PDF compilation via pdflatex and pandoc can execute arbitrary commands if -no-shell-escape is not specified.
+**Learning:** All PDF compilation processes across the codebase must enforce the -no-shell-escape flag to prevent Remote Code Execution (RCE) vulnerabilities from untrusted input.
+**Prevention:** Ensure -no-shell-escape (for pdflatex) and --pdf-engine-opt=-no-shell-escape (for pandoc) are always included in subprocess calls.

--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -799,7 +799,7 @@ Return ONLY valid JSON, nothing else."""
                             "-o",
                             str(output_path),
                             "--pdf-engine=xelatex",
-                            "--pdf-engine-opt=-no-shell-escape"
+                            "--pdf-engine-opt=-no-shell-escape",
                         ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,

--- a/cli/generators/cover_letter_generator.py
+++ b/cli/generators/cover_letter_generator.py
@@ -771,12 +771,18 @@ Return ONLY valid JSON, nothing else."""
         try:
             # Use Popen with explicit cleanup to avoid double-free issues
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=tex_path.parent,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.communicate()
+                return False
+
             if process.returncode == 0 or output_path.exists():
                 pdf_created = True
         except (subprocess.CalledProcessError, FileNotFoundError):
@@ -787,11 +793,24 @@ Return ONLY valid JSON, nothing else."""
                 # Fallback to pandoc
                 try:
                     process = subprocess.Popen(
-                        ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                        [
+                            "pandoc",
+                            str(tex_path),
+                            "-o",
+                            str(output_path),
+                            "--pdf-engine=xelatex",
+                            "--pdf-engine-opt=-no-shell-escape"
+                        ],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )
-                    stdout, stderr = process.communicate()
+                    try:
+                        stdout, stderr = process.communicate(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.communicate()
+                        return False
+
                     if process.returncode == 0 or output_path.exists():
                         pdf_created = True
                 except (subprocess.CalledProcessError, FileNotFoundError):

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -86,12 +86,17 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+                ["pdflatex", "-interaction=nonstopmode", "-no-shell-escape", tex_path.name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.communicate()
+                return False
 
             if process.returncode == 0 or output_path.exists():
                 return True
@@ -121,12 +126,24 @@ class PDFConverter:
         """
         try:
             process = subprocess.Popen(
-                ["pandoc", str(tex_path), "-o", str(output_path), "--pdf-engine=xelatex"],
+                [
+                    "pandoc",
+                    str(tex_path),
+                    "-o",
+                    str(output_path),
+                    "--pdf-engine=xelatex",
+                    "--pdf-engine-opt=-no-shell-escape"
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
             )
-            stdout, stderr = process.communicate()
+            try:
+                stdout, stderr = process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.communicate()
+                return False
 
             if process.returncode == 0 or output_path.exists():
                 return True

--- a/cli/pdf/converter.py
+++ b/cli/pdf/converter.py
@@ -132,7 +132,7 @@ class PDFConverter:
                     "-o",
                     str(output_path),
                     "--pdf-engine=xelatex",
-                    "--pdf-engine-opt=-no-shell-escape"
+                    "--pdf-engine-opt=-no-shell-escape",
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: PDF compilation via `pdflatex` and `pandoc` can execute arbitrary commands if `-no-shell-escape` is not specified, leading to potential Remote Code Execution (RCE) from untrusted input. Additionally, lack of subprocess timeouts could lead to DoS from hanging compilations.
🎯 Impact: An attacker could potentially gain unauthorized code execution privileges on the server or cause a Denial of Service by supplying malformed LaTeX input.
🔧 Fix: Added `-no-shell-escape` flag (for `pdflatex`) and `--pdf-engine-opt=-no-shell-escape` (for `pandoc`) to subprocess calls in `cli/generators/cover_letter_generator.py` and `cli/pdf/converter.py`. Added a 30-second timeout to `.communicate()` calls with proper process cleanup (catching `TimeoutExpired`, killing the process, and flushing pipes) to mitigate DoS risks.
✅ Verification: Ran `pytest tests/test_cover_letter_generator.py tests/test_cover_letter_security.py tests/test_pdf_security.py` and full `python -m pytest` test suite successfully. Evaluated and approved by code review.

---
*PR created automatically by Jules for task [1025421589653301781](https://jules.google.com/task/1025421589653301781) started by @anchapin*

## Summary by Sourcery

Mitigate security risks in LaTeX-based PDF generation by hardening external compilation subprocesses and documenting the RCE class of issues.

Bug Fixes:
- Prevent potential remote code execution in pdflatex and pandoc-based PDF compilation by disabling shell escape when compiling untrusted LaTeX content.
- Reduce denial-of-service risk from hanging PDF compilation by enforcing timeouts and terminating stalled subprocesses.

Enhancements:
- Improve robustness of PDF generation utilities by adding explicit timeout handling and cleanup around external compiler invocations.

Documentation:
- Extend Sentinel security notes with guidance on enforcing no-shell-escape for all LaTeX/PDF compilation subprocesses to prevent RCE.